### PR TITLE
open-uri required for load_uri!

### DIFF
--- a/lib/css_parser.rb
+++ b/lib/css_parser.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'open-uri'
 require 'digest/md5'
 require 'zlib'
 require 'iconv'


### PR DESCRIPTION
I was getting errors when using load_uri! until I required open-uri.

I added the require to lib/css_parser.rb

Cheers,
Trevor
