### PR TITLE
Support declarations with `;` in them

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -467,11 +467,17 @@ module CssParser
 
       block.gsub!(/(^[\s]*)|([\s]*$)/, '')
 
+      continuation = ''
       block.split(/[\;$]+/m).each do |decs|
-        if matches = decs.match(/(.[^:]*)\:(.[^;]*)(;|\Z)/i)
+        decs = continuation + decs
+        if decs =~ /\([^)]*\Z/ # if it has an unmatched parenthesis
+          continuation = decs + ';'
+
+        elsif matches = decs.match(/(.[^:]*)\s*:\s*(.+)(;?\s*\Z)/i)
           property, value, end_of_declaration = matches.captures
 
           add_declaration!(property, value)
+          continuation = ''
         end
       end
     end

--- a/test/test_rule_set.rb
+++ b/test/test_rule_set.rb
@@ -69,6 +69,13 @@ class RuleSetTests < Test::Unit::TestCase
     assert_equal(expected, actual)
   end
 
+  def test_each_declaration_containing_semicolons
+    rs = RuleSet.new(nil, "background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAiCAMAAAB7);" +
+                          "background-repeat: no-repeat")
+    assert_equal('url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAiCAMAAAB7);', rs['background-image'])
+    assert_equal('no-repeat;', rs['background-repeat'])
+  end
+
   def test_multiple_selectors_to_s
     selectors = "#content p, a"
     rs = RuleSet.new(selectors, "color: #fff;")


### PR DESCRIPTION
Declarations whose value contains a semicolon (e.g. base64-embedded image URLs) get chopped up prematurely.

This fix looks for unmatched parentheses and ignore semicolons inside them. Test included.
