### PR TITLE
more tests (and fixes) for background gradients

### DIFF
--- a/lib/css_parser/regexps.rb
+++ b/lib/css_parser/regexps.rb
@@ -22,7 +22,7 @@ module CssParser
 
   RE_URI = Regexp.new('(url\([\s]*([\s]*' + RE_STRING.to_s + '[\s]*)[\s]*\))|(url\([\s]*([!#$%&*\-~]|' + RE_NON_ASCII.to_s + '|' + RE_ESCAPE.to_s + ')*[\s]*)\)', Regexp::IGNORECASE | Regexp::EXTENDED  | Regexp::MULTILINE, 'n')
   URI_RX = /url\(("([^"]*)"|'([^']*)'|([^)]*))\)/im
-  RE_GRADIENT = /[a-z\-]*gradient\([a-z ,#%0-9\(\)]*\)$/im
+  RE_GRADIENT = /[-a-z]*gradient\([-a-z0-9 .,#%()]*\)/im
 
   # Initial parsing
   RE_AT_IMPORT_RULE = /\@import[\s]+(url\()?["''"]?(.[^'"\s"']*)["''"]?\)?([\w\s\,^\])]*)\)?;?/

--- a/test/test_css_parser_regexps.rb
+++ b/test/test_css_parser_regexps.rb
@@ -45,9 +45,11 @@ class CssParserRegexpTests < Test::Unit::TestCase
   
   def test_gradients
     ['linear-gradient(bottom, rgb(197,112,191) 7%, rgb(237,146,230) 54%, rgb(255,176,255) 77%)',
+     'linear-gradient(top, hsla(0, 0%, 0%, 0.00) 0%, hsla(0, 0%, 0%, 0.20) 100%)',
      '-o-linear-gradient(bottom, rgb(197,112,191) 7%, rgb(237,146,230) 54%, rgb(255,176,255) 77%)',
      '-moz-linear-gradient(bottom, rgb(197,112,191) 7%, rgb(237,146,230) 54%, rgb(255,176,255) 77%)',
      '-webkit-linear-gradient(bottom, rgb(197,112,191) 7%, rgb(237,146,230) 54%, rgb(255,176,255) 77%)',
+     '-webkit-gradient(linear, left top, left bottom, color-stop(0, hsla(0, 0%, 0%, 0.00)), color-stop(1, hsla(0, 0%, 0%, 0.20)))',
      '-ms-linear-gradient(bottom, rgb(197,112,191) 7%, rgb(237,146,230) 54%, rgb(255,176,255) 77%)'].each do |grad|
        assert_match(CssParser::RE_GRADIENT, grad)
     end

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -183,6 +183,18 @@ class RuleSetExpandingShorthandTests < Test::Unit::TestCase
     end
   end
 
+  def test_getting_background_gradient_from_shorthand
+    ['linear-gradient(top, hsla(0, 0%, 0%, 0.00) 0%, hsla(0, 0%, 0%, 0.20) 100%)',
+     '-webkit-gradient(linear, left top, left bottom, color-stop(0, hsla(0, 0%, 0%, 0.00)), color-stop(1, hsla(0, 0%, 0%, 0.20)))',
+     '-moz-linear-gradient(bottom, blue, red)'
+      ].each do |image|
+
+      shorthand = "background: #0f0f0f #{image} repeat ;"
+      declarations = expand_declarations(shorthand)
+      assert_equal(image, declarations['background-image'])
+    end
+  end
+
   # ==== List-style shorthand
   def test_getting_list_style_properties_from_shorthand
     expected = {'list-style-image' => 'url(\'chess.png\')', 'list-style-type' => 'katakana',


### PR DESCRIPTION
- trailing $ in gradient regexp was preventing them from being parsed at all
- more gradient expression cases added to tests
