### PR TITLE
Added support for http status code redirects

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -447,7 +447,7 @@ module CssParser
           if res.code.to_i >= 400
             raise RemoteFileError if @options[:io_exceptions]
             return '', nil
-          elsif res.code.to_i == 302
+          elsif res.code.to_i == 301 or res.code.to_i == 302
             if res.response['Location'] != nil
               return read_remote_file Addressable::URI.parse(URI::encode(res.response['Location']))
             end

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -447,6 +447,10 @@ module CssParser
           if res.code.to_i >= 400
             raise RemoteFileError if @options[:io_exceptions]
             return '', nil
+          elsif res.code.to_i == 302
+            if res.response['Location'] != nil
+              return read_remote_file Addressable::URI.parse(URI::encode(res.response['Location']))
+            end
           end
 
           case res['content-encoding']


### PR DESCRIPTION
Requests the new URL instead. This might need some polishing or
modifications.

**Edit:** To elaborate, I was scraping some HTML pages for stylesheets and tried to parse the files. On a certain site, I received a status code 302. The stylesheet had been moved, and css_parser threw an error. This patch requests the new location instead and returns that.