### PR TITLE
Improve perf of `create_dimensions_shorthand!`

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -366,8 +366,9 @@ module CssParser
        'border-style' => 'border-%s-style', 
        'border-width' => 'border-%s-width'}.each do |property, expanded|
 
-        foldable = @declarations.select do |dim, val| 
-          dim == expanded % 'top' or dim == expanded % 'right' or dim == expanded % 'bottom' or dim == expanded % 'left'
+        top, right, bottom, left = ['top', 'right', 'bottom', 'left'].map { |side| expanded % side }
+        foldable = @declarations.select do |dim, val|
+          dim == top or dim == right or dim == bottom or dim == left
         end
         # All four dimensions must be present
         if foldable.length == 4


### PR DESCRIPTION
While profiling our digest emailer I noticed a bottleneck in css_parser. Here's a simple fix.

``` ruby
require 'benchmark'

@declarations = ["hello-world", "zefro"] * 1000

Benchmark.bm do |bm|
  bm.report do
    10.times do
      {'margin'       => 'margin-%s',
       'padding'      => 'padding-%s',
       'border-color' => 'border-%s-color',
       'border-style' => 'border-%s-style',
       'border-width' => 'border-%s-width'}.each do |property, expanded|

        foldable = @declarations.select do |dim, val|
          dim == expanded % 'top' or dim == expanded % 'right' or dim == expanded % 'bottom' or dim == expanded % 'left'
        end
      end
    end
  end

  bm.report do
    10.times do
      {'margin'       => 'margin-%s',
       'padding'      => 'padding-%s',
       'border-color' => 'border-%s-color',
       'border-style' => 'border-%s-style',
       'border-width' => 'border-%s-width'}.each do |property, expanded|

        right = expanded % 'right'
        top = expanded % 'top'
        left = expanded % 'left'
        bottom = expanded % 'bottom'
        foldable = @declarations.select do |dim, val|
          dim == top or dim == right or dim == bottom or dim == left
        end
      end
    end
  end

  bm.report do
    10.times do
      {'margin'       => 'margin-%s',
       'padding'      => 'padding-%s',
       'border-color' => 'border-%s-color',
       'border-style' => 'border-%s-style',
       'border-width' => 'border-%s-width'}.each do |property, expanded|

        properties = ['top', 'right', 'bottom', 'left'].map { |dir| expanded % dir }
        foldable = @declarations.select do |dim, val|
          properties.include? dim
        end
      end
    end
  end
end
# >>        user     system      total        real
# >>    0.360000   0.000000   0.360000 (  0.362463)
# >>    0.030000   0.000000   0.030000 (  0.022585)
# >>    0.030000   0.000000   0.030000 (  0.036982)
```
