### PR TITLE
Use URI#request_uri instead of URI#path.

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -439,7 +439,7 @@ module CssParser
             http = Net::HTTP.new(uri.host, uri.port)
           end
 
-          res = http.get(uri.path, {'User-Agent' => USER_AGENT, 'Accept-Encoding' => 'gzip'})
+          res = http.get(uri.request_uri, {'User-Agent' => USER_AGENT, 'Accept-Encoding' => 'gzip'})
           src = res.body
           charset = fh.respond_to?(:charset) ? fh.charset : 'utf-8'
 


### PR DESCRIPTION
`URI#path` does not include the querystring, but `URI#request_uri`
does. So we should use that, instead.

Fixes #40.
