### PR TITLE
Respect the :import option.

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -119,25 +119,27 @@ module CssParser
       end
 
       # Load @imported CSS
-      block.scan(RE_AT_IMPORT_RULE).each do |import_rule|
-        media_types = []
-        if media_string = import_rule[-1]
-          media_string.split(/[,]/).each do |t|
-            media_types << CssParser.sanitize_media_query(t) unless t.empty?
+      if @options[:import]
+        block.scan(RE_AT_IMPORT_RULE).each do |import_rule|
+          media_types = []
+          if media_string = import_rule[-1]
+            media_string.split(/[,]/).each do |t|
+              media_types << CssParser.sanitize_media_query(t) unless t.empty?
+            end
+          else
+            media_types = [:all]
           end
-        else
-          media_types = [:all]
-        end
 
-        next unless options[:only_media_types].include?(:all) or media_types.length < 1 or (media_types & options[:only_media_types]).length > 0
+          next unless options[:only_media_types].include?(:all) or media_types.length < 1 or (media_types & options[:only_media_types]).length > 0
 
-        import_path = import_rule[0].to_s.gsub(/['"]*/, '').strip
+          import_path = import_rule[0].to_s.gsub(/['"]*/, '').strip
 
-        if options[:base_uri]
-          import_uri = Addressable::URI.parse(options[:base_uri].to_s) + Addressable::URI.parse(import_path)
-          load_uri!(import_uri, options[:base_uri], media_types)
-        elsif options[:base_dir]
-          load_file!(import_path, options[:base_dir], media_types)
+          if options[:base_uri]
+            import_uri = Addressable::URI.parse(options[:base_uri].to_s) + Addressable::URI.parse(import_path)
+            load_uri!(import_uri, options[:base_uri], media_types)
+          elsif options[:base_dir]
+            load_file!(import_path, options[:base_dir], media_types)
+          end
         end
       end
 

--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -88,6 +88,20 @@ class CssParserLoadingTests < Test::Unit::TestCase
     assert_equal 'margin: 0px;', @cp.find_by_selector('p').join(' ')
   end
 
+  def test_imports_disabled
+    cp = Parser.new(:import => false)
+    cp.load_uri!("#{@uri_base}/import1.css")
+
+    # from '/import1.css'
+    assert_equal 'color: lime;', cp.find_by_selector('div').join(' ')
+
+    # from '/subdir/import2.css'
+    assert_equal '', cp.find_by_selector('a').join(' ')
+
+    # from '/subdir/../simple.css'
+    assert_equal '', cp.find_by_selector('p').join(' ')
+  end
+
   def test_following_badly_escaped_import_rules
     css_block = '@import "http://example.com/css?family=Droid+Sans:regular,bold|Droid+Serif:regular,italic,bold,bolditalic&subset=latin";'
 


### PR DESCRIPTION
The inline documentation describes an `:import` option that determines whether the parser loads CSS specified using an `@import` statement.

This setting is broken in the master branch. CSS `@import` statements are processed even when `:import` is set to false.

This pull request fixes the code to respect the `:import` option.
