### PR TITLE
Fix bug not setting general rules after media query

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -325,7 +325,7 @@ module CssParser
 
             # reset the current media query scope
             if in_media_block
-              current_media_queries = []
+              current_media_queries = [:all]
               in_media_block = false
             end
           else

--- a/test/test_css_parser_media_types.rb
+++ b/test/test_css_parser_media_types.rb
@@ -69,6 +69,18 @@ class CssParserMediaTypesTests < Test::Unit::TestCase
     assert @cp.find_by_selector('body', :handheld).empty?
   end
 
+  def test_adding_block_with_media_types_followed_by_general_rule
+    @cp.add_block!(<<-CSS)
+      @media print {
+        body { font-size: 10pt }
+      }
+
+      body { color: black; }
+    CSS
+
+    assert_match 'color: black;', @cp.to_s
+  end
+
   def test_adding_block_and_limiting_media_types1
     css = <<-CSS
       @import "import1.css", print


### PR DESCRIPTION
This commit fixes a bug in CssParser::Parser#parse_block_into_rule_sets!
where the media_type was not being set for general rules that followed a
media query rule. This bug subsequently led to the result of
CssParser::Parser#to_s producing css strings that lacked these specific
rules, since that method organizes styles by media type.

The fix was to set the `current_media_queries` variable inside
`#parse_block_into_rule_sets!` back to `:all` after we finish iterating
through a media query, since that is the default state.