### PR TITLE
Do not short single properties

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -310,14 +310,19 @@ module CssParser
     # Combine several properties into a shorthand one
     def create_shorthand_properties! properties, shorthand_property # :nodoc:
       values = []
+      properties_to_delete = []
       properties.each do |property|
-         if @declarations.has_key?(property) and not @declarations[property][:is_important]
+        if @declarations.has_key?(property) and not @declarations[property][:is_important]
           values << @declarations[property][:value]
-           @declarations.delete(property)
-         end
-       end
+          properties_to_delete << property
+        end
+      end
 
-      unless values.empty?
+      if values.length > 1
+        properties_to_delete.each do |property|
+          @declarations.delete(property)
+        end
+
         @declarations[shorthand_property] = {:value => values.join(' ')}
       end
     end

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -125,6 +125,15 @@ class RuleSetCreatingShorthandTests < Test::Unit::TestCase
     assert_equal('url(http://example.com/1528/www/top-logo.jpg) no-repeat top right;', rs['background'])
   end
 
+
+  def test_a_single_property_is_not_shorted
+    properties = {'background-color' => 'gray'}
+    combined = create_shorthand(properties)
+
+    assert_equal('gray;', combined['background-color'])
+    assert_equal('', combined['background'])
+  end
+
   protected
 
   def assert_properties_are_deleted(ruleset, properties)


### PR DESCRIPTION
This PR prevents css_parser to convert single declarations to their respective shorthand.

So, if there is a single declaration in a selector like `background-color: #fff;`, it won't be converted to `background: #fff` and thus it won't overwrite declarations like `background-image` on other css rules.
