### PR TITLE
Include uri in RemoteFileError message.

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -489,7 +489,7 @@ module CssParser
           end
         end
       rescue
-        raise RemoteFileError if @options[:io_exceptions]
+        raise RemoteFileError.new(uri.to_s) if @options[:io_exceptions]
         return nil, nil
       end
 

--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -150,9 +150,12 @@ class CssParserLoadingTests < Test::Unit::TestCase
   def test_toggling_not_found_exceptions
     cp_with_exceptions = Parser.new(:io_exceptions => true)
 
-    assert_raise RemoteFileError do
+    err = assert_raise RemoteFileError do
       cp_with_exceptions.load_uri!("#{@uri_base}/no-exist.xyz")
     end
+
+    uri_regex = Regexp.new(Regexp.escape("#{@uri_base}/no-exist.xyz"))
+    assert_match uri_regex, err.message
 
     cp_without_exceptions = Parser.new(:io_exceptions => false)
 


### PR DESCRIPTION
Adding the uri makes it easier to figure out which uri is failing to load.
