### PR TITLE
Fix a block with no media query after a block with a media query.

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -154,6 +154,9 @@ module CssParser
     # +media_types+ can be a symbol or an array of symbols.
     def add_rule!(selectors, declarations, media_types = :all)
       rule_set = RuleSet.new(selectors, declarations)
+      if media_types.length == 0
+        media_types << :all
+      end
       add_rule_set!(rule_set, media_types)
     end
 

--- a/test/test_css_parser_media_types.rb
+++ b/test/test_css_parser_media_types.rb
@@ -122,4 +122,18 @@ class CssParserMediaTypesTests < Test::Unit::TestCase
     @cp.add_rule!('body', 'color: black;', 'aural and (device-aspect-ratio: 16/9)')
     assert_equal "@media aural and (device-aspect-ratio: 16/9) {\n  body {\n    color: black;\n  }\n}\n", @cp.to_s
   end
+
+  def test_all_block_after_media_query_block
+    @cp.load_string!('
+      @media (max-width: 1000px) {
+        body {
+          color: black;
+        }
+      }
+      p {
+        color: red;
+      }
+    ')
+    assert_equal "@media (max-width: 1000px) {\n  body {\n    color: black;\n  }\n}\np {\ncolor: red;\n}\n", @cp.to_s
+  end
 end


### PR DESCRIPTION
Hi there...

It looks like css_parser is setting media_types to `[]` rather than `[:all]` when a block with no media query follows a block with a media query, which as far as I know is valid CSS.

This pull request solves my immediate problem, but this may well not be the best way to fix it -- I won't be offended if you rewrite it.  :)

Cheers,

Matt
