### PR TITLE
Border shorthand expand fixes + tests

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -9,7 +9,7 @@ module CssParser
 
     # Array of selector strings.
     attr_reader   :selectors
-    
+
     # Integer with the specificity to use for this RuleSet.
     attr_accessor   :specificity
 
@@ -55,7 +55,7 @@ module CssParser
         @declarations.delete(property)
         return
       end
-      
+
       value.gsub!(/;\Z/, '')
       is_important = !value.gsub!(CssParser::IMPORTANT_IN_PROPERTY_RX, '').nil?
       property = property.downcase.strip
@@ -166,7 +166,7 @@ module CssParser
         split_declaration(k, "#{k}-color", value.slice!(CssParser::RE_COLOUR))
         split_declaration(k, "#{k}-style", value.slice!(CssParser::RE_BORDER_STYLE))
 
-        @declarations.delete(k)   
+        @declarations.delete(k)
       end
     end
 
@@ -175,20 +175,20 @@ module CssParser
     def expand_dimensions_shorthand! # :nodoc:
       {'margin'       => 'margin-%s',
        'padding'      => 'padding-%s',
-       'border-color' => 'border-%s-color', 
-       'border-style' => 'border-%s-style', 
+       'border-color' => 'border-%s-color',
+       'border-style' => 'border-%s-style',
        'border-width' => 'border-%s-width'}.each do |property, expanded|
 
         next unless @declarations.has_key?(property)
-        
+
         value = @declarations[property][:value]
 
         # RGB and HSL values in borders are the only units that can have spaces (within params).
-        # We cheat a bit here by stripping spaces after commas in RGB and HSL values so that we 
+        # We cheat a bit here by stripping spaces after commas in RGB and HSL values so that we
         # can split easily on spaces.
         #
         # TODO: rgba, hsl, hsla
-        value.gsub!(RE_COLOUR) { |c| c.gsub(/[\s]+/, '') }
+        value.gsub!(RE_COLOUR) { |c| c.gsub(/(\s?\,\s?)/, ',') }
 
         matches = value.strip.split(/[\s]+/)
 
@@ -329,14 +329,14 @@ module CssParser
     def create_background_shorthand! # :nodoc:
       create_shorthand_properties! BACKGROUND_PROPERTIES, 'background'
     end
-    
+
     # Combine border-color, border-style and border-width into border
     # Should be run after create_dimensions_shorthand!
     #
     # TODO: this is extremely similar to create_background_shorthand! and should be combined
     def create_border_shorthand! # :nodoc:
       values = []
-      
+
       ['border-width', 'border-style', 'border-color'].each do |property|
         if @declarations.has_key?(property) and not @declarations[property][:is_important]
           # can't merge if any value contains a space (i.e. has multiple values)
@@ -354,16 +354,16 @@ module CssParser
         @declarations['border'] = {:value => values.join(' ')}
       end
     end
-    
-    # Looks for long format CSS dimensional properties (margin, padding, border-color, border-style and border-width) 
+
+    # Looks for long format CSS dimensional properties (margin, padding, border-color, border-style and border-width)
     # and converts them into shorthand CSS properties.
     def create_dimensions_shorthand! # :nodoc:
       directions = ['top', 'right', 'bottom', 'left']
 
       {'margin'       => 'margin-%s',
        'padding'      => 'padding-%s',
-       'border-color' => 'border-%s-color', 
-       'border-style' => 'border-%s-style', 
+       'border-color' => 'border-%s-color',
+       'border-style' => 'border-%s-style',
        'border-width' => 'border-%s-width'}.each do |property, expanded|
 
         top, right, bottom, left = ['top', 'right', 'bottom', 'left'].map { |side| expanded % side }
@@ -377,7 +377,7 @@ module CssParser
           directions.each { |d| values[d.to_sym] = @declarations[expanded % d][:value].downcase.strip }
 
           if values[:left] == values[:right]
-            if values[:top] == values[:bottom] 
+            if values[:top] == values[:bottom]
               if values[:top] == values[:left] # All four sides are equal
                 new_value = values[:top]
               else # Top and bottom are equal, left and right are equal
@@ -400,8 +400,8 @@ module CssParser
     end
 
 
-    # Looks for long format CSS font properties (e.g. <tt>font-weight</tt>) and 
-    # tries to convert them into a shorthand CSS <tt>font</tt> property.  All 
+    # Looks for long format CSS font properties (e.g. <tt>font-weight</tt>) and
+    # tries to convert them into a shorthand CSS <tt>font</tt> property.  All
     # font properties must be present in order to create a shorthand declaration.
     def create_font_shorthand! # :nodoc:
       ['font-style', 'font-variant', 'font-weight', 'font-size',
@@ -449,17 +449,17 @@ module CssParser
 
       if @declarations.has_key?(dest)
         #puts "dest #{dest} already exists"
-      
+
         if @declarations[dest][:order] > @declarations[src][:order]
-          #puts "skipping #{dest}:#{v} due to order "        
+          #puts "skipping #{dest}:#{v} due to order "
           return
         else
-          @declarations[dest] = {}    
+          @declarations[dest] = {}
         end
       end
-      @declarations[dest] = @declarations[src].merge({:value => v.to_s.strip})    
+      @declarations[dest] = @declarations[src].merge({:value => v.to_s.strip})
     end
-  
+
     def parse_declarations!(block) # :nodoc:
       @declarations = {}
 

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -35,6 +35,10 @@ class RuleSetCreatingShorthandTests < Test::Unit::TestCase
     properties = {'border-top-style' => 'none', 'border-right-style' => 'none', 'border-bottom-style' => 'none', 'border-left-style' => 'none'}
     combined = create_shorthand(properties)
     assert_equal 'none;', combined['border']
+
+    properties = {'border-top-color' => '#bada55', 'border-right-color' => '#000000', 'border-bottom-color' => '#ffffff', 'border-left-color' => '#ff0000'}
+    combined = create_shorthand(properties)
+    assert_equal '#bada55 #000000 #ffffff #ff0000;', combined['border-color']
   end
 
   # Dimensions shorthand

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -21,6 +21,27 @@ class RuleSetExpandingShorthandTests < Test::Unit::TestCase
     assert_equal 'rgb(2%,2%,2%)', declarations['border-bottom-color']
     assert_equal 'hsla(255,0,0,5)', declarations['border-left-color']
 
+    declarations = expand_declarations('border-color: #000000 #bada55 #ffffff #ff0000')
+
+    assert_equal '#000000', declarations['border-top-color']
+    assert_equal '#bada55', declarations['border-right-color']
+    assert_equal '#ffffff', declarations['border-bottom-color']
+    assert_equal '#ff0000', declarations['border-left-color']
+
+    declarations = expand_declarations('border-color: #000000 #bada55 #ffffff')
+
+    assert_equal '#000000', declarations['border-top-color']
+    assert_equal '#bada55', declarations['border-right-color']
+    assert_equal '#ffffff', declarations['border-bottom-color']
+    assert_equal '#bada55', declarations['border-left-color']
+
+    declarations = expand_declarations('border-color: #000000 #bada55')
+
+    assert_equal '#000000', declarations['border-top-color']
+    assert_equal '#bada55', declarations['border-right-color']
+    assert_equal '#000000', declarations['border-bottom-color']
+    assert_equal '#bada55', declarations['border-left-color']
+
     declarations = expand_declarations('border: thin dot-dot-dash')
     assert_equal 'dot-dot-dash', declarations['border-left-style']
     assert_equal 'thin', declarations['border-left-width']


### PR DESCRIPTION
Hi guys, there seem to have been a bug, where `border-color: #000 #fff` etc... wasn't correctly expanded. This PR aims to fix this. I've also included some test cases.

Hope this fix can be merged.

P.S. not entirely sure why  `test_following_badly_escaped_import_rules` is failing in `test/test_css_parser_loading.rb`. Also, do I need to include version bump commit in this PR?