### PR TITLE
Encoding fix

### DIFF
--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -103,7 +103,7 @@ class CssParserLoadingTests < Test::Unit::TestCase
   end
 
   def test_following_badly_escaped_import_rules
-    css_block = '@import "http://example.com/css?family=Droid+Sans:regular,bold|Droid+Serif:regular,italic,bold,bolditalic&subset=latin";'
+    css_block = '@import "http://fonts.googleapis.com/css?family=Droid+Sans:regular,bold|Droid+Serif:regular,italic,bold,bolditalic&subset=latin";'
 
     assert_nothing_raised do
       @cp.add_block!(css_block, :base_uri => "#{@uri_base}/subdir/")


### PR DESCRIPTION
I had the issue that the css file contained bad UTF-8 characters, so I added options when encoding the string to UTF-8 (which it'll do now always) to skip any invalid characters. 
Also, travis doesn't check with ruby 1.8 anymore, so I dropped ruby 1.8 support to simplify things.
