### PR TITLE
Added some tests to check for the malformed CSS in content blocks

### DIFF
--- a/test/fixtures/import-malformed.css
+++ b/test/fixtures/import-malformed.css
@@ -1,0 +1,35 @@
+.malformed.one:before {
+  content: "\\";
+  color: "red";
+}
+
+.wellformed.one {
+  color: "green";
+}
+
+.malformed.two:before {
+  content: "\"";
+  color: "red";
+}
+
+.wellformed.two {
+  color: "green";
+}
+
+.malformed.three:before {
+  content: "{";
+  color: "red";
+}
+
+.wellformed.three {
+  color: "green";
+}
+
+.malformed.four:before {
+  content: "}";
+  color: "red";
+}
+
+.wellformed.four {
+  color: "green";
+}

--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -128,6 +128,25 @@ class CssParserLoadingTests < Minitest::Test
     end
   end
 
+  def test_loading_malformed_content_strings
+    file_name = File.dirname(__FILE__) + '/fixtures/import-malformed.css'
+    @cp.load_file!(file_name)
+    @cp.each_selector do |sel, dec, spec|
+      assert_nil dec =~ /wellformed/
+    end
+  end
+
+  def test_loading_malformed_css_brackets
+    file_name = File.dirname(__FILE__) + '/fixtures/import-malformed.css'
+    @cp.load_file!(file_name)
+    selector_count = 0
+    @cp.each_selector do |sel, dec, spec|
+      selector_count += 1
+    end
+
+    assert_equal 8, selector_count
+  end
+
   def test_following_at_import_rules_from_add_block
     css_block = '@import "../simple.css";'
 


### PR DESCRIPTION
I've added in a few tests to help with the malformed parsing from our most  recent changes.