### PR TITLE
Add support for background-size in the shorthand property

### DIFF
--- a/lib/css_parser/regexps.rb
+++ b/lib/css_parser/regexps.rb
@@ -47,6 +47,7 @@ module CssParser
   BOX_MODEL_UNITS_RX = /(auto|inherit|0|([\-]*([0-9]+|[0-9]*\.[0-9]+)(e[mx]+|px|[cm]+m|p[tc+]|in|\%)))([\s;]|\Z)/imx
   RE_LENGTH_OR_PERCENTAGE = Regexp.new('([\-]*(([0-9]*\.[0-9]+)|[0-9]+)(e[mx]+|px|[cm]+m|p[tc+]|in|\%))', Regexp::IGNORECASE)
   RE_BACKGROUND_POSITION = Regexp.new("((((#{RE_LENGTH_OR_PERCENTAGE})|left|center|right|top|bottom)[\s]*){1,2})", Regexp::IGNORECASE | Regexp::EXTENDED)
+  RE_BACKGROUND_SIZE = Regexp.new("\\s*/\\s*((((#{RE_LENGTH_OR_PERCENTAGE})|auto|cover|contain|initial|inherit)[\\s]*){1,2})", Regexp::IGNORECASE | Regexp::EXTENDED)
   FONT_UNITS_RX = /(([x]+\-)*small|medium|large[r]*|auto|inherit|([0-9]+|[0-9]*\.[0-9]+)(e[mx]+|px|[cm]+m|p[tc+]|in|\%)*)/i
   RE_BORDER_STYLE = /([\s]*^)?(none|hidden|dotted|dashed|solid|double|dot-dash|dot-dot-dash|wave|groove|ridge|inset|outset)([\s]*$)?/imx
   RE_BORDER_UNITS = Regexp.union(BOX_MODEL_UNITS_RX, /(thin|medium|thick)/i)

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -102,6 +102,19 @@ class RuleSetCreatingShorthandTests < Minitest::Test
     assert_properties_are_deleted(combined, properties)
   end
 
+  def test_combining_background_with_size_into_shorthand
+    properties = {'background-image' => 'url(\'chess.png\')', 'background-color' => 'gray',
+      'background-position' => 'center -10.2%', 'background-attachment' => 'fixed',
+      'background-repeat' => 'no-repeat', 'background-size' => '50% 100%'}
+
+    combined = create_shorthand(properties)
+
+    assert_equal('gray url(\'chess.png\') no-repeat center -10.2% / 50% 100% fixed;', combined['background'])
+
+    # after creating shorthand, all long-hand properties should be deleted
+    assert_properties_are_deleted(combined, properties)
+  end
+
 
   # List-style shorthand
   def test_combining_list_style_into_shorthand

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -147,6 +147,20 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     end
   end
 
+  def test_getting_background_size_from_shorthand
+    ['em', 'ex', 'in', 'px', 'pt', 'pc', '%'].each do |unit|
+      shorthand = "background: url('chess.png') gray 30% -0.20/-0.15#{unit} auto repeat fixed;"
+      declarations = expand_declarations(shorthand)
+      assert_equal("-0.15#{unit} auto", declarations['background-size'])
+    end
+
+    ['cover', 'contain', 'auto', 'initial', 'inherit'].each do |size|
+      shorthand = "background: url('chess.png') #000fff 0% 50% / #{size} no-repeat fixed;"
+      declarations = expand_declarations(shorthand)
+      assert_equal(size, declarations['background-size'])
+    end
+  end
+
   def test_getting_background_colour_from_shorthand
     ['blue', 'lime', 'rgb(10,10,10)', 'rgb (  -10%, 99, 300)', '#ffa0a0', '#03c', 'trAnsparEnt', 'inherit'].each do |colour|
       shorthand = "background:#{colour} url('chess.png') center repeat fixed ;"


### PR DESCRIPTION
The `background` property supports background size in addition to the other long-form properties. When we have a separate `background-size` property and when we create a shorthand version, we must include the `background-size` in the shorthand by preceding it with a  slash: `/` and vice versa—when we’re parsing a shorthand property, we must look for and fetch the `background-size` before we extract
`background-position` as otherwise it might be ambiguous.

This should fix premailer/premailer#252 and premailer/premailer#216.