### PR TITLE
fix bug when there is no background-position but a background-size when creating shorthand

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -340,7 +340,7 @@ module CssParser
       # http://www.w3schools.com/cssref/css3_pr_background.asp
       if @declarations.has_key?('background-size') and not @declarations['background-size'][:is_important]
         unless @declarations.has_key?('background-position')
-          @declarations['background-position'] = {value => 'initial'}
+          @declarations['background-position'] = {:value => 'initial'}
         end
 
         @declarations['background-size'][:value] = "/ #{@declarations['background-size'][:value]}"

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -115,7 +115,7 @@ class RuleSetCreatingShorthandTests < Minitest::Test
     assert_properties_are_deleted(combined, properties)
   end
 
-  def test_combinig_background_with_size_and_no_position_into_shorthand
+  def test_combining_background_with_size_and_no_position_into_shorthand
     properties = {'background-image' => 'url(\'chess.png\')', 'background-color' => 'gray',
       'background-attachment' => 'fixed', 'background-repeat' => 'no-repeat',
       'background-size' => '50% 100%'}

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -115,6 +115,18 @@ class RuleSetCreatingShorthandTests < Minitest::Test
     assert_properties_are_deleted(combined, properties)
   end
 
+  def test_combinig_background_with_size_and_no_position_into_shorthand
+    properties = {'background-image' => 'url(\'chess.png\')', 'background-color' => 'gray',
+      'background-attachment' => 'fixed', 'background-repeat' => 'no-repeat',
+      'background-size' => '50% 100%'}
+
+    combined = create_shorthand(properties)
+
+    assert_equal('gray url(\'chess.png\') no-repeat initial / 50% 100% fixed;', combined['background'])
+
+    # after creating shorthand, all long-hand properties should be deleted
+    assert_properties_are_deleted(combined, properties)
+  end
 
   # List-style shorthand
   def test_combining_list_style_into_shorthand


### PR DESCRIPTION
The latest release of css_parser introduction a bug when creating shorthand for background. If there is a background-size, but not a background-position, there is a ruby error `undefined local variable or method 'value'`

value was missing a colon, it should be a symbol not a variable. I fixed this and added a test for this case.