### PR TITLE
Normalize whitespace in selectors and queries

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -80,6 +80,8 @@ module CssParser
       rule_sets = []
 
       selectors.each do |selector|
+        selector.gsub!(/\s+/, ' ')
+        selector.strip!
         each_rule_set(media_types) do |rule_set, media_type|
           if !rule_sets.member?(rule_set) && rule_set.selectors.member?(selector)
             rule_sets << rule_set

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -505,7 +505,7 @@ module CssParser
     # TODO: way too simplistic
     #++
     def parse_selectors!(selectors) # :nodoc:
-      @selectors = selectors.split(',').map { |s| s.strip }
+      @selectors = selectors.split(',').map { |s| s.gsub(/\s+/, ' ').strip }
     end
   end
 end

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -106,11 +106,15 @@ class CssParserTests < Minitest::Test
       h1, h2 { color: blue; }
       h1 { font-size: 10px; }
       h2 { font-size: 5px; }
+      article  h3  { color: black; }
+      article
+      h3 { background-color: white; }
     CSS
 
     @cp.add_block!(css)
     assert_equal 2, @cp.find_rule_sets(["h2"]).size
     assert_equal 3, @cp.find_rule_sets(["h1", "h2"]).size
+    assert_equal 2, @cp.find_rule_sets(["article h3"]).size
   end
 
   def test_calculating_specificity

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -115,6 +115,7 @@ class CssParserTests < Minitest::Test
     assert_equal 2, @cp.find_rule_sets(["h2"]).size
     assert_equal 3, @cp.find_rule_sets(["h1", "h2"]).size
     assert_equal 2, @cp.find_rule_sets(["article h3"]).size
+    assert_equal 2, @cp.find_rule_sets(["  article \t  \n  h3 \n "]).size
   end
 
   def test_calculating_specificity


### PR DESCRIPTION
Extra whitespace in form of multiple spaces, tabs, line feeds, carriage returns and form feeds within CSS selectors and in queries might not be a beauty. But as I understand the spec, multiple elements within a selector should be "whitespace-separated", and it includes all those kinds of whitespaces. [¹](#footnote1)

This topic branched pull request adds tests and support for both selectors and queries with extra whitespace by normalizing it.

<a name="footnote1">[1]</a>: https://www.w3.org/TR/css3-selectors/#selector-syntax