### PR TITLE
Fix use of inital value for background-position in shorthand.

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -340,7 +340,7 @@ module CssParser
       # http://www.w3schools.com/cssref/css3_pr_background.asp
       if @declarations.has_key?('background-size') and not @declarations['background-size'][:is_important]
         unless @declarations.has_key?('background-position')
-          @declarations['background-position'] = {:value => 'initial'}
+          @declarations['background-position'] = {:value => '0% 0%'}
         end
 
         @declarations['background-size'][:value] = "/ #{@declarations['background-size'][:value]}"

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -126,7 +126,7 @@ class RuleSetCreatingShorthandTests < Minitest::Test
 
     combined = create_shorthand(properties)
 
-    assert_equal('gray url(\'chess.png\') no-repeat initial / 50% 100% fixed;', combined['background'])
+    assert_equal('gray url(\'chess.png\') no-repeat 0% 0% / 50% 100% fixed;', combined['background'])
 
     # after creating shorthand, all long-hand properties should be deleted
     assert_properties_are_deleted(combined, properties)


### PR DESCRIPTION
The use of the `initial` keyword as the value for the `background-position` in the background shorthand is causing the CSS to be invalid (at least in every browser I was able to test). Using the [stated default](http://www.w3schools.com/cssref/pr_background-position.asp) of `0% 0%` instead resolves the issue.

You can see the issue in action in this [Codepen](http://codepen.io/ehlertij/pen/bBoqBE). Open the inspector to see the broken CSS:

<img width="608" alt="screen shot 2016-11-28 at 12 54 19 pm" src="https://cloud.githubusercontent.com/assets/174227/20685595/d2540298-b569-11e6-980a-4776702f7cd3.png">

My company ran into the issue after upgrading to the latest version of the gem and had to roll it back to before this was introduced as a result. Issue was introduced in #65 and #66.

Let me know if you need anything else from me on this one.

**Update:**

According to [this page on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/background#Formal_syntax), it appears that `initial` is not a valid value for the shorthand:

```
<position> = [[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ]]
```
(notice how `initial` does not appear)