### PR TITLE
Ensure order key exists in declaration array for all property short to long conversions

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -476,7 +476,12 @@ module CssParser
           @declarations[dest] = {}
         end
       end
-      @declarations[dest] = @declarations[src].merge({:value => v.to_s.strip})
+      @declarations[dest] =
+        @declarations[src].merge(
+          {
+            value: v.to_s.strip,
+            order: @declarations[src][:order] || @order += 1
+          })
     end
 
     def parse_declarations!(block) # :nodoc:


### PR DESCRIPTION
If an `:order` key does not exist on a source or destination `@declaration`, then the comparison for order fails because we are comparing `nil` to an integer.

This pertains to issue https://github.com/premailer/css_parser/issues/81