### PR TITLE
Handles font-size/ line-height shorthand with spaces

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -241,6 +241,7 @@ module CssParser
        end
 
       value = @declarations['font'][:value]
+      value.gsub!(/\/\s+/, '/') # handle spaces between font size and height shorthand (e.g. 14px/ 16px)
       is_important = @declarations['font'][:is_important]
       order = @declarations['font'][:order]
 

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -146,6 +146,13 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     end
   end
 
+  def test_getting_line_height_from_shorthand_with_spaces
+    ['em', 'ex', 'in', 'px', 'pt', 'pc', '%'].each do |unit|
+      shorthand = "font: 300 italic 12px/ 0.25#{unit} verdana, helvetica, sans-serif;"
+      declarations = expand_declarations(shorthand)
+      assert_equal("0.25#{unit}", declarations['line-height'])
+    end
+  end
 
   # Background shorthand
   def test_getting_background_properties_from_shorthand


### PR DESCRIPTION
### Description

While attempting use Premailer to inline CSS for emails originating from Amazon, we started seeing errors when expanding font shorthands that have spaces after the forward slash - e.g `font-size/ line-height`:

```
NoMethodError: undefined method `strip' for nil:NilClass
/bundle/gems/css_parser-1.5.0/lib/css_parser/rule_set.rb:99:in `block in each_declaration'
/bundle/gems/css_parser-1.5.0/lib/css_parser/rule_set.rb:97:in `each'
/bundle/gems/css_parser-1.5.0/lib/css_parser/rule_set.rb:97:in `each_declaration'
/bundle/gems/css_parser-1.5.0/lib/css_parser.rb:81:in `block in merge'
/bundle/gems/css_parser-1.5.0/lib/css_parser.rb:69:in `each'
/bundle/gems/css_parser-1.5.0/lib/css_parser.rb:69:in `merge'
...
```

An example of the email body particulars:
```
...
a {
	text-decoration: none;
	color: #006699;
	font: 14px/ 16px Arial, sans-serif;=09
}
...
f_=3Dpe_2640190_232748420_TE_simp_" title=3D"Visit Amazon.com" style=3D"tex=
t-decoration: none; color: rgb(0, 102, 153); font: 14px/ 16px Arial, sans-s=
erif"><img id=3D"amazonLogo" alt=3D"Amazon" src=3D"http://g-ecx.images-amaz=
on.com/images/G/01/x-locale/cs/te/logo.png" style=3D"width: 107px; height: =
31px; border: 0" /></a> </td>=20
...
```

What it renders like in a browser:
![amazon_email_example](https://user-images.githubusercontent.com/2507399/30204324-e8289da4-9439-11e7-94ed-f14b24723ce7.png)



### Tasks

- [ ] Any other tests?
- [ ] Should a space/spaces be allowed before the `/`?
- [ ] Should some nil safety be added to line 446/447 in rule_set.rb to address `TypeError: no implicit conversion of nil into String`? (this fix _should address this...)
- [ ] Fix failing ruby 1.9.3 test

@grosser, thoughts?