### PR TITLE
Parser#each_selector returns Enumerator if not given block

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -242,6 +242,8 @@ module CssParser
     # +media_types+ can be a symbol or an array of symbols.
     # See RuleSet#each_selector for +options+.
     def each_selector(all_media_types = :all, options = {}) # :yields: selectors, declarations, specificity, media_types
+      return to_enum(:each_selector) unless block_given?
+
       each_rule_set(all_media_types) do |rule_set, media_types|
         rule_set.each_selector(options) do |selectors, declarations, specificity|
           yield selectors, declarations, specificity, media_types

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -182,4 +182,20 @@ class CssParserTests < Minitest::Test
     rule = RuleSet.new('div', '{content: url(data:image/png;base64,LOTSOFSTUFF)}')
     assert_includes rule.to_s, "image/png;base64,LOTSOFSTUFF"
   end
+
+  def test_enumerator_empty
+    assert_kind_of Enumerator, @cp.each_selector
+  end
+
+  def test_enumerator_nonempty
+    @cp.add_block! 'body {color: black;}'
+
+    assert_kind_of Enumerator, @cp.each_selector
+
+    enumerator = @cp.each_selector
+    @cp.each_selector.each do |sel, desc, spec|
+      assert_equal 'body', sel
+      assert_equal 'color: black;', desc
+    end
+  end
 end


### PR DESCRIPTION
(I was working with css_parser today, wanted to `parser.each_selector.collect { ...`, but it raised `LocalJumpError`.)