### PR TITLE
Prevent non-important declaration taking over prior important

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -60,6 +60,9 @@ module CssParser
       is_important = !value.gsub!(CssParser::IMPORTANT_IN_PROPERTY_RX, '').nil?
       property = property.downcase.strip
       #puts "SAVING #{property}  #{value} #{is_important.inspect}"
+      return if @declarations.has_key?(property) &&
+                @declarations[property][:is_important] &&
+                !is_important
       @declarations[property] = {
         :value => value, :is_important => is_important, :order => @order += 1
       }

--- a/test/test_rule_set.rb
+++ b/test/test_rule_set.rb
@@ -76,6 +76,36 @@ class RuleSetTests < Minitest::Test
     assert_equal('no-repeat;', rs['background-repeat'])
   end
 
+  def test_rule_set_only_has_latest_when_declaration_defined_twice
+    css_fragment = "margin: 0; padding: 20px; margin-bottom: 28px; padding: 40px;"
+    rs           = RuleSet.new(nil, css_fragment)
+    expected     = %w(margin margin-bottom padding)
+    actual       = []
+    rs.each_declaration { |prop, val, imp| actual << prop }
+    assert_equal(expected, actual)
+    assert_equal('40px;', rs['padding'])
+  end
+
+  def test_rule_set_respects_first_important_declaration_when_defined_twice
+    css_fragment = "margin: 0; padding: 20px !important; margin-bottom: 28px; padding: 40px;"
+    rs           = RuleSet.new(nil, css_fragment)
+    expected     = %w(margin padding margin-bottom)
+    actual       = []
+    rs.each_declaration { |prop, val, imp| actual << prop }
+    assert_equal(expected, actual)
+    assert_equal('20px !important;', rs['padding'])
+  end
+
+  def test_rule_set_respects_second_important_declaration_when_defined_twice_and_both_important
+    css_fragment = "margin: 0; padding: 20px !important; margin-bottom: 28px; padding: 40px !important;"
+    rs           = RuleSet.new(nil, css_fragment)
+    expected     = %w(margin margin-bottom padding)
+    actual       = []
+    rs.each_declaration { |prop, val, imp| actual << prop }
+    assert_equal(expected, actual)
+    assert_equal('40px !important;', rs['padding'])
+  end
+
   def test_selector_sanitization
     selectors = "h1, h2,\nh3 "
     rs = RuleSet.new(selectors, "color: #fff;")


### PR DESCRIPTION
Prior `!important` declarations should not be overridden by subsequent same-property declarations that are not `!important`.

Hypothetical example:
```
a {
  color: #fff !important;
  // some other stuff
  color: #000;
}
```
From this, the parser should produce the relevant `a` RuleSet resolve to the following:
```
a {
  color: #fff !important;
  // some other stuff
}
```
Otherwise, for all other situations, the subsequent declaration should overwrite the first.

This isn't happening currently, but this PR addresses this issue and tests for it.