### PR TITLE
Fix parsing of multiline URL values for rule sets

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -616,7 +616,7 @@ module CssParser
         decs = (continuation ? continuation + decs : decs)
         if decs =~ /\([^)]*\Z/ # if it has an unmatched parenthesis
           continuation = "#{decs};"
-        elsif (matches = decs.match(/\s*(.[^:]*)\s*:\s*(.+?)(?:;?\s*\Z)/i))
+        elsif (matches = decs.match(/\s*(.[^:]*)\s*:\s*(?m:(.+))(?:;?\s*\Z)/i))
           # skip end_of_declaration
           property = matches[1]
           value = matches[2]

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -113,6 +113,26 @@ class CssParserTests < Minitest::Test
     end
   end
 
+  def test_multiline_declarations
+    css = <<-CSS
+      @font-face {
+        font-family: 'some_font';
+        src: url(https://example.com/font.woff2) format('woff2'),
+             url(https://example.com/font.woff) format('woff');
+        font-style: normal;
+      }
+    CSS
+
+    @cp.add_block!(css)
+    @cp.each_selector do |selector, declarations, _spec|
+      assert_equal '@font-face', selector
+      assert_equal "font-family: 'some_font'; " \
+                   "src: url(https://example.com/font.woff2) format('woff2')," \
+                        "url(https://example.com/font.woff) format('woff'); " \
+                   "font-style: normal;", declarations
+    end
+  end
+
   def test_find_rule_sets
     css = <<-CSS
       h1, h2 { color: blue; }


### PR DESCRIPTION
Currently, parsing doesn't work properly for CSS rules with multiline URL values. Here's what happens:

```ruby
font_face = "@font-face {\n src: url(https://example.com/font.woff2), \n url(https://example.com/font.woff); } \n"
CssParser::Parser.new.tap { |parser| parser.add_block!(font_face) }.to_s
# => "@font-face {\n://example.com/font.woff2),url(https: //example.com/font.woff);\n}\n"
```

This is due to the regex here: https://github.com/premailer/css_parser/blob/57647747cb8b9eb517b0e70949b3e23b777645f5/lib/css_parser/rule_set.rb#L501

Amending this regex to `/(.[^:]*)\s*:\s*(?m:(.+))(;?\s*\Z)/i` (which essentially allows multiline capturing of a CSS rule's value capture group) fixes this issue.

I'm not a regex pro so I'm not sure if this is the best solution. Thoughts?