### PR TITLE
Reduce Allocations to reduce memory usage

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -401,7 +401,7 @@ module CssParser
       DIMENSIONS.each do |property, dimensions|
         (top, right, bottom, left) = dimensions
         # All four dimensions must be present
-        if dimensions.inject(0) { |c, d| c += 1 if @declarations[d]; c } == 4
+        if dimensions.count { |d| @declarations[d] } == 4
           values = {}
 
           [

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -107,7 +107,7 @@ module CssParser
     # TODO: Clean-up regexp doesn't seem to work
     #++
     def declarations_to_s(options = {})
-     options = {:force_important => false}.merge(options)
+     options[:force_important] ||= false
      str = String.new
      each_declaration do |prop, val, is_important|
        importance = (options[:force_important] || is_important) ? ' !important' : ''
@@ -491,7 +491,9 @@ module CssParser
           @declarations[dest] = {}
         end
       end
-      @declarations[dest] = @declarations[src].merge({:value => v.to_s.strip})
+
+      @declarations[dest] = @declarations[src].dup
+      @declarations[dest][:value] = v.to_s.strip
     end
 
     def parse_declarations!(block) # :nodoc:

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -111,15 +111,16 @@ module CssParser
     # TODO: Clean-up regexp doesn't seem to work
     #++
     def declarations_to_s(options = {})
-     options[:force_important] ||= false
-     str = String.new
-     each_declaration do |prop, val, is_important|
-       importance = (options[:force_important] || is_important) ? ' !important' : ''
-       str << "#{prop}: #{val}#{importance}; "
-     end
-     str.gsub!(/^[\s^(\{)]+|[\n\r\f\t]*|[\s]+$/mx, '')
-     str.strip!
-     str
+      options = options.dup
+      options[:force_important] ||= false
+      str = String.new
+      each_declaration do |prop, val, is_important|
+        importance = (options[:force_important] || is_important) ? ' !important' : ''
+        str << "#{prop}: #{val}#{importance}; "
+      end
+      str.gsub!(/^[\s^(\{)]+|[\n\r\f\t]*|[\s]+$/mx, '')
+      str.strip!
+      str
     end
 
     # Return the CSS rule set as a string.

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -7,6 +7,9 @@ module CssParser
 
     BACKGROUND_PROPERTIES = ['background-color', 'background-image', 'background-repeat', 'background-position', 'background-size', 'background-attachment']
     LIST_STYLE_PROPERTIES = ['list-style-type', 'list-style-position', 'list-style-image']
+    FONT_STYLE_PROPERTIES = ['font-style', 'font-variant', 'font-weight', 'font-size', 'line-height', 'font-family']
+    BORDER_STYLE_PROPERTIES = ['border-width', 'border-style', 'border-color']
+    BORDER_PROPERTIES = ['border', 'border-left', 'border-right', 'border-top', 'border-bottom']
 
     # Array of selector strings.
     attr_reader   :selectors
@@ -168,7 +171,7 @@ module CssParser
     # Split shorthand border declarations (e.g. <tt>border: 1px red;</tt>)
     # Additional splitting happens in expand_dimensions_shorthand!
     def expand_border_shorthand! # :nodoc:
-      ['border', 'border-left', 'border-right', 'border-top', 'border-bottom'].each do |k|
+      BORDER_PROPERTIES.each do |k|
         next unless @declarations.has_key?(k)
 
         value = @declarations[k][:value]
@@ -366,7 +369,7 @@ module CssParser
     def create_border_shorthand! # :nodoc:
       values = []
 
-      ['border-width', 'border-style', 'border-color'].each do |property|
+      BORDER_STYLE_PROPERTIES.each do |property|
         if @declarations.has_key?(property) and not @declarations[property][:is_important]
           # can't merge if any value contains a space (i.e. has multiple values)
           # we temporarily remove any spaces after commas for the check (inside rgba, etc...)
@@ -375,9 +378,7 @@ module CssParser
         end
       end
 
-      @declarations.delete('border-width')
-      @declarations.delete('border-style')
-      @declarations.delete('border-color')
+      BORDER_STYLE_PROPERTIES.each { |prop| @declarations.delete(prop)}
 
       unless values.empty?
         @declarations['border'] = {:value => values.join(' ')}
@@ -438,8 +439,7 @@ module CssParser
     # tries to convert them into a shorthand CSS <tt>font</tt> property.  All
     # font properties must be present in order to create a shorthand declaration.
     def create_font_shorthand! # :nodoc:
-      ['font-style', 'font-variant', 'font-weight', 'font-size',
-       'line-height', 'font-family'].each do |prop|
+     FONT_STYLE_PROPERTIES.each do |prop|
         return unless @declarations.has_key?(prop)
       end
 
@@ -460,11 +460,7 @@ module CssParser
 
       @declarations['font'] = {:value => new_value.gsub(/[\s]+/, ' ').strip}
 
-      ['font-style', 'font-variant', 'font-weight', 'font-size',
-       'line-height', 'font-family'].each do |prop|
-       @declarations.delete(prop)
-      end
-
+      FONT_STYLE_PROPERTIES.each { |prop| @declarations.delete(prop) }
     end
 
     # Looks for long format CSS list-style properties (e.g. <tt>list-style-type</tt>) and

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -11,6 +11,7 @@ module CssParser
     BORDER_STYLE_PROPERTIES = ['border-width', 'border-style', 'border-color']
     BORDER_PROPERTIES = ['border', 'border-left', 'border-right', 'border-top', 'border-bottom']
 
+    NUMBER_OF_DIMENSIONS = 4
     # Array of selector strings.
     attr_reader   :selectors
 
@@ -396,12 +397,12 @@ module CssParser
     # Looks for long format CSS dimensional properties (margin, padding, border-color, border-style and border-width)
     # and converts them into shorthand CSS properties.
     def create_dimensions_shorthand! # :nodoc:
-      return if @declarations.size < 4
+      return if @declarations.size < NUMBER_OF_DIMENSIONS
 
       DIMENSIONS.each do |property, dimensions|
         (top, right, bottom, left) = dimensions
         # All four dimensions must be present
-        if dimensions.count { |d| @declarations[d] } == 4
+        if dimensions.count { |d| @declarations[d] } == NUMBER_OF_DIMENSIONS
           values = {}
 
           [


### PR DESCRIPTION
While using the `premailer` gem with a background worker, I noticed that our excessive GC was slowing our mail jobs down. The main culprit, is this gem. 
I took 3 approaches to reducing allocations and memory usage.

1. reduce dynamic string creation for border properties. (This can also be done for `expand_dimensions_shorthand`
2. Reduced hash allocations
3. Reduces string allocations when parsing a complex document. 

Overall, allocated memory was reduced by 25% and object allocation was reduced by 27%. 

### Before
```
Total allocated: 6873180 bytes (96310 objects)
Total retained:  5585 bytes (58 objects)

allocated memory by gem
-----------------------------------
   6861148  css_parser/lib
     10776  racc
      1256  other


allocated objects by class
-----------------------------------
     57903  String
     20809  Array
     14161  Hash
      3243  MatchData
       179  CssParser::RuleSet
        15  Racc::CparseParams

```

### After

```
Total allocated: 5172596 bytes (70638 objects)
Total retained:  5585 bytes (58 objects)

allocated memory by gem
-----------------------------------
   5160564  css_parser/lib
     10776  racc
      1256  other

allocated objects by class
-----------------------------------
     43867  String
     14531  Array
      8803  Hash
      3243  MatchData
       179  CssParser::RuleSet
        15  Racc::CparseParams

```

