### PR TITLE
Provide metadata for RubyGems

### DIFF
--- a/css_parser.gemspec
+++ b/css_parser.gemspec
@@ -10,4 +10,10 @@ Gem::Specification.new name, CssParser::VERSION do |s|
   s.add_runtime_dependency 'addressable'
   s.files = Dir.glob("lib/**/*") + ["MIT-LICENSE"]
   s.license = "MIT"
+  
+  if s.respond_to?(:metadata)
+    s.metadata['changelog_uri'] = "https://github.com/premailer/css_parser/blob/master/CHANGELOG.md"
+    s.metadata['source_code_uri'] = "https://github.com/premailer/css_parser"
+    s.metadata['bug_tracker_uri'] = "https://github.com/premailer/css_parser/issues"
+  end
 end

--- a/css_parser.gemspec
+++ b/css_parser.gemspec
@@ -11,9 +11,7 @@ Gem::Specification.new name, CssParser::VERSION do |s|
   s.files = Dir.glob("lib/**/*") + ["MIT-LICENSE"]
   s.license = "MIT"
   
-  if s.respond_to?(:metadata)
-    s.metadata['changelog_uri'] = "https://github.com/premailer/css_parser/blob/master/CHANGELOG.md"
-    s.metadata['source_code_uri'] = "https://github.com/premailer/css_parser"
-    s.metadata['bug_tracker_uri'] = "https://github.com/premailer/css_parser/issues"
-  end
+  s.metadata['changelog_uri'] = "https://github.com/premailer/css_parser/blob/master/CHANGELOG.md"
+  s.metadata['source_code_uri'] = "https://github.com/premailer/css_parser"
+  s.metadata['bug_tracker_uri'] = "https://github.com/premailer/css_parser/issues"
 end


### PR DESCRIPTION
This inserts the direct links to changelog/bugs in RubyGems. It also allows easier automatic processing of updates.