### PR TITLE
Force UTF-8 encoding; do not strip out UTF-8 chars.

### DIFF
--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -533,7 +533,7 @@ module CssParser
     # Returns a string.
     def cleanup_block(block, options = {}) # :nodoc:
       # Strip CSS comments
-      utf8_block = block.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: ' ')
+      utf8_block = block.encode('UTF-8', 'UTF-8', invalid: :replace, undef: :replace, replace: ' ')
       utf8_block = ignore_pattern(utf8_block, STRIP_CSS_COMMENTS_RX, options)
 
       # Strip HTML comments - they shouldn't really be in here but

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -8,6 +8,16 @@ class CssParserTests < Minitest::Test
     @cp = Parser.new
   end
 
+  def test_utf8
+    css = <<-CSS
+      .chinese { font-family: "Microsoft YaHei","微软雅黑"; }
+    CSS
+
+    @cp.add_block!(css)
+
+    assert_equal 'font-family: "Microsoft YaHei","微软雅黑";', @cp.find_by_selector('.chinese').join(' ')
+  end
+
   def test_at_page_rule
     # from http://www.w3.org/TR/CSS21/page.html#page-selectors
     css = <<-CSS


### PR DESCRIPTION
The line changed was causing UTF-8 chars to be stripped out in the CSS parsing. UTF-8 chars are needed for 'font-family' of Asian fonts. Not sure why binary encoding was used here previously.

```
font-family: "Helvetica Neue","Microsoft YaHei UI","Microsoft YaHei New","Microsoft YaHei","微软雅黑","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji",sans-serif,system-ui;
```