### PR TITLE
Add testing with Ruby 2.7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
-sudo: false
 cache: bundler
 before_install: rm Gemfile.lock
 rvm:
-  - 2.2.3
-  - 2.3.1
-  - 2.4.0
-  - 2.5.3
-  - 2.6.0
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-head


### PR DESCRIPTION
* Removes deprecated 'sudo: false' option.
* Only defines MAJOR.MINOR version so the latest available version
  will be picked.