### PR TITLE
Fixup flags on RE_URI

### DIFF
--- a/lib/css_parser/regexps.rb
+++ b/lib/css_parser/regexps.rb
@@ -20,7 +20,7 @@ module CssParser
 
   RE_INHERIT = regex_possible_values 'inherit'
 
-  RE_URI = Regexp.new(/(url\(\s*(\s*#{RE_STRING}\s*)\s*\))|(url\(\s*([!#$%&*\-~]|#{RE_NON_ASCII}|#{RE_ESCAPE})*\s*)\)/, Regexp::IGNORECASE | Regexp::EXTENDED | Regexp::MULTILINE, 'n').freeze
+  RE_URI = /(url\(\s*(\s*#{RE_STRING}\s*)\s*\))|(url\(\s*([!#$%&*\-~]|#{RE_NON_ASCII}|#{RE_ESCAPE})*\s*)\)/ixm.freeze
   URI_RX = /url\(("([^"]*)"|'([^']*)'|([^)]*))\)/im.freeze
   RE_GRADIENT = /[-a-z]*gradient\([-a-z0-9 .,#%()]*\)/im.freeze
 


### PR DESCRIPTION
Flags are not applied if regexp is passed to `Regexp.new`
`lib/css_parser/regexps.rb:23: warning: flags ignored`

Fixes 2d228d14