### PR TITLE
Fixup benchmark & add `RuleSet::DeclarationValue`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,11 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    benchmark-ips (2.8.4)
     bump (0.10.0)
     maxitest (3.6.0)
       minitest (>= 5.0.0, < 5.14.0)
+    memory_profiler (1.0.0)
     minitest (5.12.0)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -40,12 +42,15 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
+  benchmark-ips
   bump
   css_parser!
   maxitest
+  memory_profiler
   rake
   rubocop (~> 1.8)
   rubocop-rake

--- a/css_parser.gemspec
+++ b/css_parser.gemspec
@@ -19,8 +19,10 @@ Gem::Specification.new name, CssParser::VERSION do |s|
 
   s.add_runtime_dependency 'addressable'
 
+  s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'bump'
   s.add_development_dependency 'maxitest'
+  s.add_development_dependency 'memory_profiler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop', '~> 1.8'
   s.add_development_dependency 'rubocop-rake'

--- a/test/rule_set/test_declaration_value.rb
+++ b/test/rule_set/test_declaration_value.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'minitest/spec'
+
+class RuleSetProperyTest < Minitest::Test
+  describe '.new' do
+    describe 'with invalid value' do
+      it 'raises an error when empty' do
+        exception = assert_raises(ArgumentError) { CssParser::RuleSet::DeclarationValue.new('  ') }
+        assert_equal 'value is empty', exception.message
+      end
+
+      it 'raises an error when nil' do
+        exception = assert_raises(ArgumentError) { CssParser::RuleSet::DeclarationValue.new(nil) }
+        assert_equal 'value is empty', exception.message
+      end
+
+      it 'raises an error when contains only important declaration' do
+        exception = assert_raises(ArgumentError) { CssParser::RuleSet::DeclarationValue.new(' !important; ') }
+        assert_equal 'value is empty', exception.message
+      end
+    end
+
+    describe 'with valid value' do
+      it 'remove semicolon at the end' do
+        assert_equal 'value', CssParser::RuleSet::DeclarationValue.new('value;').value
+      end
+
+      it 'removes important declarations' do
+        assert_equal 'value', CssParser::RuleSet::DeclarationValue.new('value !important').value
+      end
+
+      it 'strips value' do
+        assert_equal 'value', CssParser::RuleSet::DeclarationValue.new('  value ').value
+      end
+
+      it 'does everything above' do
+        assert_equal "value\t another one",
+          CssParser::RuleSet::DeclarationValue.new("  \tvalue\t another one  \t!important  \t  ;  ").value
+      end
+
+      it 'freezes the string' do
+        assert_equal true, CssParser::RuleSet::DeclarationValue.new('value').value.frozen?
+      end
+    end
+
+    describe 'important' do
+      describe 'when not set' do
+        it 'is not important if value is not important' do
+          assert_equal false, CssParser::RuleSet::DeclarationValue.new('value').important
+        end
+
+        it 'is important if value is not important' do
+          assert_equal true, CssParser::RuleSet::DeclarationValue.new('value !important;').important
+        end
+      end
+
+      describe 'when set' do
+        it 'overrides value importance' do
+          assert_equal false, CssParser::RuleSet::DeclarationValue.new('value !important;', important: false).important
+          assert_equal true, CssParser::RuleSet::DeclarationValue.new('value', important: true).important
+        end
+      end
+    end
+
+    describe 'order' do
+      it 'zero when not set' do
+        assert_equal 0, CssParser::RuleSet::DeclarationValue.new('value').order
+      end
+
+      it 'returns proper value if set' do
+        assert_equal 42, CssParser::RuleSet::DeclarationValue.new('value', order: 42).order
+      end
+    end
+  end
+
+  describe 'order=' do
+    it 'sets order' do
+      property = CssParser::RuleSet::DeclarationValue.new('value')
+      assert_equal 0, property.order
+
+      property.order = 42
+      assert_equal 42, property.order
+    end
+  end
+
+  describe 'important=' do
+    it 'sets importance' do
+      property = CssParser::RuleSet::DeclarationValue.new('value')
+      assert_equal false, property.important
+
+      property.important = true
+      assert_equal true, property.important
+    end
+  end
+
+  describe 'value=' do
+    it 'sets normalized value' do
+      property = CssParser::RuleSet::DeclarationValue.new('foo')
+      assert_equal 'foo', property.value
+
+      property.value = "  \tvalue\t another one  \t!important  \t  ;  "
+      assert_equal "value\t another one", property.value
+    end
+
+    it 'freezes the string' do
+      property = CssParser::RuleSet::DeclarationValue.new('foo')
+      property.value = 'bar'
+
+      assert_equal true, CssParser::RuleSet::DeclarationValue.new('value').value.frozen?
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns value if not important' do
+      assert_equal 'value', CssParser::RuleSet::DeclarationValue.new('value').to_s
+    end
+
+    it 'returns value with important annotation if important' do
+      assert_equal 'value !important', CssParser::RuleSet::DeclarationValue.new('value', important: true).to_s
+    end
+  end
+end


### PR DESCRIPTION
Also fix rake task, `.join('test/fixtures')` returns invalid absolute path.
Extract from https://github.com/premailer/css_parser/pull/115.

`bundle exec rake benchmark` results

Before:
```
Executing: bundle exec rake benchmark
Warming up --------------------------------------
 import1.css loading   363.000  i/100ms
 complex.css loading    16.000  i/100ms
Calculating -------------------------------------
 import1.css loading      4.087k (± 3.6%) i/s -     20.691k in   5.069769s
 complex.css loading    160.094  (± 6.9%) i/s -    800.000  in   5.026577s

Loading `import1.css` allocated 348 objects, 25 KiB
Loading `complex.css` allocated 9111 objects, 704 KiB
```

After:
```
Executing: bundle exec rake benchmark
Warming up --------------------------------------
 import1.css loading   410.000  i/100ms
 complex.css loading    15.000  i/100ms
Calculating -------------------------------------
 import1.css loading      3.947k (± 4.7%) i/s -     20.090k in   5.101062s
 complex.css loading    156.845  (± 1.9%) i/s -    795.000  in   5.070007s

Loading `import1.css` allocated 363 objects, 26 KiB
Loading `complex.css` allocated 10010 objects, 740 KiB
```
Overall comparable, but it's big variability.

Anyway, I'm pretty sure that it's slightly slower, but the cause is freezing/duplicating of the values, which is arguably correctness fix.

I'll try to take a look at performance after this series is merged.