### PR TITLE
Preserve rules priority while expanding shorthands

### DIFF
--- a/test/rule_set/declarations/test_value.rb
+++ b/test/rule_set/declarations/test_value.rb
@@ -63,26 +63,6 @@ class RuleSetProperyTest < Minitest::Test
         end
       end
     end
-
-    describe 'order' do
-      it 'zero when not set' do
-        assert_equal 0, CssParser::RuleSet::Declarations::Value.new('value').order
-      end
-
-      it 'returns proper value if set' do
-        assert_equal 42, CssParser::RuleSet::Declarations::Value.new('value', order: 42).order
-      end
-    end
-  end
-
-  describe 'order=' do
-    it 'sets order' do
-      property = CssParser::RuleSet::Declarations::Value.new('value')
-      assert_equal 0, property.order
-
-      property.order = 42
-      assert_equal 42, property.order
-    end
   end
 
   describe 'important=' do
@@ -102,6 +82,17 @@ class RuleSetProperyTest < Minitest::Test
 
       property.value = "  \tvalue\t another one  \t!important  \t  ;  "
       assert_equal "value\t another one", property.value
+    end
+
+    it 'sets importance' do
+      property = CssParser::RuleSet::Declarations::Value.new('foo')
+      assert_equal 'foo', property.value
+      assert_equal false, property.important
+
+      property.value = 'bar !important'
+
+      assert_equal 'bar', property.value
+      assert_equal true, property.important
     end
 
     it 'freezes the string' do

--- a/test/rule_set/test_declarations.rb
+++ b/test/rule_set/test_declarations.rb
@@ -13,13 +13,13 @@ class RuleSetDeclarationsTest < Minitest::Test
 
     describe 'when initial declarations is given' do
       it 'initialized with given declarations' do
-        baz_property = CssParser::RuleSet::Declarations::Value.new('baz value', order: 42, important: true)
+        baz_property = CssParser::RuleSet::Declarations::Value.new('baz value', important: true)
         declarations = CssParser::RuleSet::Declarations.new({foo: 'foo value', bar: 'bar value', baz: baz_property})
 
         assert_equal 3, declarations.size
 
-        assert_equal CssParser::RuleSet::Declarations::Value.new('foo value', order: 1), declarations['foo']
-        assert_equal CssParser::RuleSet::Declarations::Value.new('bar value', order: 2), declarations[:bar]
+        assert_equal CssParser::RuleSet::Declarations::Value.new('foo value'), declarations['foo']
+        assert_equal CssParser::RuleSet::Declarations::Value.new('bar value'), declarations[:bar]
         assert_equal baz_property, declarations['baz']
       end
     end
@@ -38,7 +38,7 @@ class RuleSetDeclarationsTest < Minitest::Test
 
     it 'assigns proper value if Declarations::Value is given' do
       declarations = CssParser::RuleSet::Declarations.new
-      property = CssParser::RuleSet::Declarations::Value.new('value', important: true, order: 42)
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
 
       declarations['foo'] = property
 
@@ -72,21 +72,21 @@ class RuleSetDeclarationsTest < Minitest::Test
 
   describe '#[]' do
     it 'returns property if exists' do
-      foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', important: true, order: 42)
+      foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', important: true)
       declarations = CssParser::RuleSet::Declarations.new({foo: foo_value})
 
       assert_equal foo_value, declarations['foo']
     end
 
     it 'returns nil if not exists' do
-      foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', important: true, order: 42)
+      foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', important: true)
       declarations = CssParser::RuleSet::Declarations.new({foo: foo_value})
 
       assert_nil declarations['bar']
     end
 
     it 'normalizes property name' do
-      foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', important: true, order: 42)
+      foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', important: true)
       declarations = CssParser::RuleSet::Declarations.new({foo: foo_value})
 
       assert_equal foo_value, declarations[:'Foo ']
@@ -135,7 +135,7 @@ class RuleSetDeclarationsTest < Minitest::Test
     end
   end
 
-  describe '#remove_declaration' do
+  describe '#delete' do
     it 'removes declaration if exists' do
       declarations = CssParser::RuleSet::Declarations.new({foo: 'foo value'})
       assert_equal 1, declarations.size
@@ -163,35 +163,221 @@ class RuleSetDeclarationsTest < Minitest::Test
 
       assert_equal 0, declarations.size
     end
+
+    it 'has alias #remove_declaration!' do
+      declarations = CssParser::RuleSet::Declarations.new
+
+      assert_equal declarations.method(:delete), declarations.method(:remove_declaration!)
+    end
+  end
+
+  describe '#replace_declaration!' do
+    it 'raises an error when replaced property does not exist' do
+      declarations = CssParser::RuleSet::Declarations.new
+
+      exception = assert_raises(ArgumentError) { declarations.replace_declaration!('property_name', {}) }
+      assert_equal 'property property_name does not exist', exception.message
+    end
+
+    it 'replaces declaration with normalized property name in place' do
+      declarations = CssParser::RuleSet::Declarations.new('foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value')
+
+      declarations.replace_declaration!("   bAr\t\n", {'bar1' => 'bar1_value', 'bar2' => 'bar2_value'})
+
+      expected = CssParser::RuleSet::Declarations.new(
+        'foo' => 'foo_value', 'bar1' => 'bar1_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value'
+      )
+      assert_equal expected, declarations
+    end
+
+    describe 'when `preserve_importance: false`' do
+      it 'does not set importance when replaced property is important' do
+        declarations = CssParser::RuleSet::Declarations.new('foo' => 'foo_value !important')
+
+        declarations.replace_declaration!('foo', {'bar' => 'bar_value', 'baz' => 'baz_value !important'})
+        expected = CssParser::RuleSet::Declarations.new({'bar' => 'bar_value', 'baz' => 'baz_value !important'})
+
+        assert_equal expected, declarations
+      end
+
+      it 'does not unset importance when replaced property is not important' do
+        declarations = CssParser::RuleSet::Declarations.new('foo' => 'foo_value')
+
+        declarations.replace_declaration!('foo', {'bar' => 'bar_value', 'baz' => 'baz_value !important'})
+        expected = CssParser::RuleSet::Declarations.new({'bar' => 'bar_value', 'baz' => 'baz_value !important'})
+
+        assert_equal expected, declarations
+      end
+    end
+
+    describe 'when `preserve_importance: true`' do
+      it 'sets importance when replaced property is important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar' => 'bar_value !important', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value !important'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value', 'bar2' => 'bar2_value'}, preserve_importance: true)
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar2' => 'bar2_value !important', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value !important'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'unsets importance when replaced property is not important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value'
+        )
+
+        declarations.replace_declaration!(
+          'bar',
+          {'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value !important'},
+          preserve_importance: true
+        )
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value'
+        )
+
+        assert_equal expected, declarations
+      end
+    end
+
+    describe 'when subsequent declarations for the replacement declarations exist' do
+      it 'does not replace declarations when both are not important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'does not replace declarations when both are important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value !important'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value !important'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'does not replace declaration when only replaced is important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value !important'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value !important'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'replaces declarations when only replacement is important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value', 'bar1' => 'old_bar1_value'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value', 'baz' => 'baz_value'
+        )
+
+        assert_equal expected, declarations
+      end
+    end
+
+    describe 'when prior declarations for the replacement declarations exist' do
+      it 'replaces declarations when both are not important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'old_bar1_value', 'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'bar1_value', 'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'replaces declarations when both are important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'old_bar1_value !important', 'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'bar1_value !important', 'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'does not replace declaration when only replaced is important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'old_bar1_value !important', 'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'old_bar1_value !important', 'foo' => 'foo_value', 'bar2' => 'bar2_value', 'baz' => 'baz_value'
+        )
+
+        assert_equal expected, declarations
+      end
+
+      it 'replaces declarations when only replacement is important' do
+        declarations = CssParser::RuleSet::Declarations.new(
+          'bar1' => 'old_bar1_value', 'foo' => 'foo_value', 'bar' => 'bar_value', 'baz' => 'baz_value'
+        )
+
+        declarations.replace_declaration!('bar', {'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value'})
+        expected = CssParser::RuleSet::Declarations.new(
+          'foo' => 'foo_value', 'bar1' => 'bar1_value !important', 'bar2' => 'bar2_value', 'baz' => 'baz_value'
+        )
+
+        assert_equal expected, declarations
+      end
+    end
   end
 
   describe '#each' do
     describe 'when block is not given' do
-      it 'returns enumerator with properties order by order' do
-        foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', order: 3)
-        bar_value = CssParser::RuleSet::Declarations::Value.new('bar value', order: 1)
-        baz_value = CssParser::RuleSet::Declarations::Value.new('baz value', order: 2)
+      it 'returns enumerator with properties in order' do
+        foo_value = CssParser::RuleSet::Declarations::Value.new('foo value')
+        bar_value = CssParser::RuleSet::Declarations::Value.new('bar value')
+        baz_value = CssParser::RuleSet::Declarations::Value.new('baz value')
 
         declarations = CssParser::RuleSet::Declarations.new({foo: foo_value, bar: bar_value, baz: baz_value})
 
         assert_instance_of Enumerator, declarations.each
         assert_equal 3, declarations.each.size
-        assert_equal [['bar', bar_value], ['baz', baz_value], ['foo', foo_value]], declarations.each.to_a
+        assert_equal [['foo', foo_value], ['bar', bar_value], ['baz', baz_value]], declarations.each.to_a
       end
     end
 
     describe 'when block is given' do
-      it 'yields properties order by order' do
-        foo_value = CssParser::RuleSet::Declarations::Value.new('foo value', order: 3)
-        bar_value = CssParser::RuleSet::Declarations::Value.new('bar value', order: 1)
-        baz_value = CssParser::RuleSet::Declarations::Value.new('baz value', order: 2)
+      it 'yields properties in order' do
+        foo_value = CssParser::RuleSet::Declarations::Value.new('foo value')
+        bar_value = CssParser::RuleSet::Declarations::Value.new('bar value')
+        baz_value = CssParser::RuleSet::Declarations::Value.new('baz value')
 
         declarations = CssParser::RuleSet::Declarations.new({foo: foo_value, bar: bar_value, baz: baz_value})
 
         mock = Minitest::Mock.new
+        mock.expect :call, true, ['foo', foo_value]
         mock.expect :call, true, ['bar', bar_value]
         mock.expect :call, true, ['baz', baz_value]
-        mock.expect :call, true, ['foo', foo_value]
 
         declarations.each { |name, value| mock.call(name, value) }
 
@@ -224,6 +410,55 @@ class RuleSetDeclarationsTest < Minitest::Test
         assert_equal 'foo: foo value !important; bar: bar value !important; baz: baz value !important;',
           declarations.to_s({force_important: true})
       end
+    end
+  end
+
+  describe '#==' do
+    it 'returns true if declarations & their order are the same' do
+      declarations_hash = {'foo' => 'foo_value', 'bar' => 'bar_value'}
+      declarations = CssParser::RuleSet::Declarations.new(declarations_hash)
+      other = CssParser::RuleSet::Declarations.new(declarations_hash)
+
+      assert_equal declarations, other
+    end
+
+    it 'returns false if other is not a Declarations' do
+      declarations_hash = {'foo' => 'foo_value', 'bar' => 'bar_value'}
+      declarations = CssParser::RuleSet::Declarations.new(declarations_hash)
+      other = OpenStruct.new(declarations: declarations_hash)
+
+      refute_equal declarations, other
+    end
+
+    it 'returns true if value is a Declarations subclass and declarations are equal' do
+      declarations_hash = {'foo' => 'foo_value', 'bar' => 'bar_value'}
+      declarations = CssParser::RuleSet::Declarations.new(declarations_hash)
+      other_class = Class.new(CssParser::RuleSet::Declarations)
+      other = other_class.new(declarations_hash)
+
+      assert_equal declarations, other
+    end
+
+    it 'returns false if value is a Declarations subclass and value are not equal' do
+      declarations = CssParser::RuleSet::Declarations.new({'foo' => 'foo_value', 'bar' => 'bar_value'})
+      other_class = Class.new(CssParser::RuleSet::Declarations)
+      other = other_class.new({'bar' => 'bar_value', 'foo' => 'foo_value'})
+
+      refute_equal declarations, other
+    end
+
+    it 'returns false if declarations values are different' do
+      declarations = CssParser::RuleSet::Declarations.new({'foo' => 'foo_value', 'bar' => 'bar_value'})
+      other = CssParser::RuleSet::Declarations.new({'bar' => 'bar_value', 'foo' => 'other_foo_value'})
+
+      refute_equal declarations, other
+    end
+
+    it 'returns false if declarations are the same and their order is different' do
+      declarations = CssParser::RuleSet::Declarations.new({'foo' => 'foo_value', 'bar' => 'bar_value'})
+      other = CssParser::RuleSet::Declarations.new({'bar' => 'bar_value', 'foo' => 'foo_value'})
+
+      refute_equal declarations, other
     end
   end
 end

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -268,6 +268,34 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     end
   end
 
+  def test_expanding_shorthand_with_replaced_properties_after
+    shorthand = 'line-height: 0.25px !important; font-style: normal; font: small-caps italic 12px sans-serif; font-size: 12em;'
+    declarations = expand_declarations(shorthand)
+    expected_declarations = {
+      'line-height' => '0.25px',
+      'font-style' => 'italic',
+      'font-variant' => 'small-caps',
+      'font-weight' => 'normal',
+      'font-family' => 'sans-serif',
+      'font-size' => '12em'
+    }
+    assert_equal expected_declarations, declarations
+  end
+
+  def test_expanding_important_shorthand_with_replaced_properties
+    shorthand = 'line-height: 0.25px !important; font-style: normal; font: small-caps italic 12px sans-serif !important; font-size: 12em; font-family: emoji !important;'
+    declarations = expand_declarations(shorthand)
+    expected_declarations = {
+      'font-style' => 'italic',
+      'font-variant' => 'small-caps',
+      'font-weight' => 'normal',
+      'line-height' => 'normal',
+      'font-family' => 'emoji',
+      'font-size' => '12px'
+    }
+    assert_equal expected_declarations, declarations
+  end
+
 protected
 
   def expand_declarations(declarations)


### PR DESCRIPTION
We can piggyback on `Hash` preserving it's order in all supported rubies & drop order. Looks quite ugly, but does the trick.
I assume that it will be faster if we'll properly track and propagate `order` in all places, but I suspect it will be also harder to work with.

And we're little faster at parsing because of `order` is removed:
Before:
```
Executing: bundle exec rake benchmark
Warming up --------------------------------------
 import1.css loading   376.000  i/100ms
 complex.css loading    14.000  i/100ms
Calculating -------------------------------------
 import1.css loading      3.670k (± 3.6%) i/s -     18.424k in   5.027200s
 complex.css loading    142.421  (± 4.2%) i/s -    714.000  in   5.021913s

Loading `import1.css` allocated 372 objects, 26 KiB
Loading `complex.css` allocated 10437 objects, 752 KiB
```
After:
```
Executing: bundle exec rake benchmark
Warming up --------------------------------------
 import1.css loading   394.000  i/100ms
 complex.css loading    14.000  i/100ms
Calculating -------------------------------------
 import1.css loading      3.809k (± 3.7%) i/s -     19.306k in   5.075438s
 complex.css loading    147.464  (± 3.4%) i/s -    742.000  in   5.037139s

Loading `import1.css` allocated 357 objects, 25 KiB
Loading `complex.css` allocated 9536 objects, 680 KiB
```

And little slower at expanding shorthands (tested on github's 500KB css with `parser.each_rule_set { |rule_set, _media_type| rule_set.expand_shorthand! }`, not sure how relevant this file is though)
Before:
```
Executing: bundle exec ruby b.rb
Warming up --------------------------------------
github-bf18d76d7dfd1ad6ed77f31817d6c749.css loading
                         1.000  i/100ms
Calculating -------------------------------------
github-bf18d76d7dfd1ad6ed77f31817d6c749.css loading
                          2.798  (± 0.0%) i/s -     84.000  in  30.089636s
Loading `github.css` and expanding shothands allocated 439154 objects, 29732 KiB
```
After:
```
Executing: bundle exec ruby b.rb
Warming up --------------------------------------
github-bf18d76d7dfd1ad6ed77f31817d6c749.css loading
                         1.000  i/100ms
Calculating -------------------------------------
github-bf18d76d7dfd1ad6ed77f31817d6c749.css loading
                          2.789  (± 0.0%) i/s -     84.000  in  30.161549s
Loading `github.css` and expanding shothands allocated 437074 objects, 30186 KiB
Successfully rebased and updated refs/heads/fixup_expanding_shorthands.
``` 
Fixes #111