### PR TITLE
Fix `RuleSet::Declarations` tests and actually run them

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require 'rubocop/rake_task'
 require 'bump/tasks'
 
 Rake::TestTask.new do |test|
+  test.pattern = 'test/**/test*.rb'
   test.verbose = true
 end
 

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -47,6 +47,12 @@ module CssParser
 
           "#{value} !important"
         end
+
+        def ==(other)
+          return false unless other.is_a?(self.class)
+
+          value == other.value && important == other.important
+        end
       end
 
       def initialize(declarations = {})
@@ -133,7 +139,7 @@ module CssParser
       attr_reader :declarations
 
       def normalize_property(property)
-        property = property.downcase
+        property = property.to_s.downcase
         property.strip!
         property
       end

--- a/test/rule_set/declarations/test_value.rb
+++ b/test/rule_set/declarations/test_value.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
+require_relative '../../test_helper'
 require 'minitest/spec'
 
 class RuleSetProperyTest < Minitest::Test
@@ -119,6 +119,52 @@ class RuleSetProperyTest < Minitest::Test
 
     it 'returns value with important annotation if important' do
       assert_equal 'value !important', CssParser::RuleSet::Declarations::Value.new('value', important: true).to_s
+    end
+  end
+
+  describe '#==' do
+    it 'returns true if value & importance are the same' do
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+      other = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+
+      assert_equal property, other
+    end
+
+    it 'returns false if value is not a Declarations::Value' do
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+      other = OpenStruct.new(value: 'value', important: true)
+
+      refute_equal other, property
+    end
+
+    it 'returns true if value is a Declarations::Value subclass and value are equal' do
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+      other_class = Class.new(CssParser::RuleSet::Declarations::Value)
+      other = other_class.new('value', important: true)
+
+      assert_equal property, other
+    end
+
+    it 'returns false if value is a Declarations::Value subclass and value are not equal' do
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+      other_class = Class.new(CssParser::RuleSet::Declarations::Value)
+      other = other_class.new('other value', important: true)
+
+      refute_equal other, property
+    end
+
+    it 'returns false if value is different' do
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+      other = CssParser::RuleSet::Declarations::Value.new('other value', important: true)
+
+      refute_equal property, other
+    end
+
+    it 'returns false if importance is different' do
+      property = CssParser::RuleSet::Declarations::Value.new('value', important: true)
+      other = CssParser::RuleSet::Declarations::Value.new('value', important: false)
+
+      refute_equal property, other
     end
   end
 end


### PR DESCRIPTION
I noticed that new tests are not run on `bundle exec rake test` without explicit `TEST=` :facepalm: 

Also `#==` in `Value` is really needed since identical value are unequal without it. 