### PR TITLE
Prevent border shorthand when individual property isnt shortened

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -512,6 +512,11 @@ module CssParser
     def create_border_shorthand! # :nodoc:
       values = []
 
+      # can't merge if not shortened
+      declarations.each do |name, value|
+        return if %w(border-top border-right border-bottom border-left).any? { |e| name.include?(e) }
+      end
+
       BORDER_STYLE_PROPERTIES.each do |property|
         next unless (declaration = declarations[property])
         next if declaration.important

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -50,6 +50,16 @@ class RuleSetCreatingShorthandTests < Minitest::Test
     }
     combined = create_shorthand(properties)
     assert_equal '#bada55 #000000 #ffffff #ff0000;', combined['border-color']
+
+    # should not combine if individual side property is set
+    properties = {
+      'border-top-style' => 'none',
+      'border-width' => '1px',
+      'border-style' => 'solid',
+      'border-color' => 'black',
+    }
+    combined = create_shorthand(properties)
+    assert_equal '', combined['border']
   end
 
   # Dimensions shorthand


### PR DESCRIPTION
Issue https://github.com/premailer/css_parser/issues/87

Checks if any border-*side* declaration is present, as it should have been removed by `create_dimensions_shorthand!` , if there is still one left it means it's not shortable and we shouldn't replace any `border-width/style/color` property with a `border` property that would erase it.

Open for suggestions/corrections

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary
