### PR TITLE
keep border-width when border-color has spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+ * Do not combine border styles width/color/style are not all present
+
 ### Version 1.10.0
 
  * Allow CSS functions to be used in CssParser::RuleSet#expand_dimensions_shorthand! [#126](https://github.com/premailer/css_parser/pull/126)

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -513,6 +513,14 @@ module CssParser
     def create_border_shorthand! # :nodoc:
       values = []
 
+      border_style_declarations = BORDER_STYLE_PROPERTIES.map do |property|
+        declarations[property]
+      end
+
+      if border_style_declarations.compact.size != BORDER_STYLE_PROPERTIES.size
+        return
+      end
+
       BORDER_STYLE_PROPERTIES.each do |property|
         next unless (declaration = declarations[property])
         next if declaration.important

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -530,7 +530,9 @@ module CssParser
         return nil if declaration.value.gsub(/,\s/, ',').strip =~ /\s/
 
         values << declaration.value
+      end
 
+      BORDER_STYLE_PROPERTIES.each do |property|
         declarations.delete(property)
       end
 

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -511,32 +511,20 @@ module CssParser
     #
     # TODO: this is extremely similar to create_background_shorthand! and should be combined
     def create_border_shorthand! # :nodoc:
-      values = []
-
-      border_style_declarations = BORDER_STYLE_PROPERTIES.map do |property|
-        declarations[property]
-      end
-
-      if border_style_declarations.compact.size != BORDER_STYLE_PROPERTIES.size
-        return
-      end
-
-      BORDER_STYLE_PROPERTIES.each do |property|
+      values = BORDER_STYLE_PROPERTIES.map do |property|
         next unless (declaration = declarations[property])
         next if declaration.important
-
         # can't merge if any value contains a space (i.e. has multiple values)
         # we temporarily remove any spaces after commas for the check (inside rgba, etc...)
-        return nil if declaration.value.gsub(/,\s/, ',').strip =~ /\s/
+        next if declaration.value.gsub(/,\s/, ',').strip =~ /\s/
+        declaration.value
+      end.compact
 
-        values << declaration.value
-      end
+      return if values.size != BORDER_STYLE_PROPERTIES.size
 
       BORDER_STYLE_PROPERTIES.each do |property|
         declarations.delete(property)
       end
-
-      return if values.empty?
 
       declarations['border'] = values.join(' ')
     end

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -13,12 +13,22 @@ class RuleSetCreatingShorthandTests < Minitest::Test
   def test_border_width
     combined = create_shorthand(
       'border-width': '1px',
-      'border-color': 'black'
     )
 
     assert_equal '', combined['border']
     assert_equal '1px;', combined['border-width']
-    assert_equal 'black;', combined['border-color']
+  end
+
+  def test_border_width_with_border_color_with_spaces
+    combined = create_shorthand(
+      'border-width': '1px',
+      'border-color': 'rgb(0 0 0 / 1)',
+      'border-style': 'solid'
+    )
+
+    assert_equal '', combined['border']
+    assert_equal '1px;', combined['border-width']
+    assert_equal 'rgb(0 0 0 / 1);', combined['border-color']
   end
 
   # Border shorthand

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -10,6 +10,17 @@ class RuleSetCreatingShorthandTests < Minitest::Test
     @cp = CssParser::Parser.new
   end
 
+  def test_border_width
+    combined = create_shorthand(
+      'border-width': '1px',
+      'border-color': 'black'
+    )
+
+    assert_equal '', combined['border']
+    assert_equal '1px;', combined['border-width']
+    assert_equal 'black;', combined['border-color']
+  end
+
   # Border shorthand
   def test_combining_borders_into_shorthand
     properties = {
@@ -32,17 +43,22 @@ class RuleSetCreatingShorthandTests < Minitest::Test
 
     assert_equal '', combined['border-width']
 
-    properties = {'border-width' => '22%', 'border-color' => 'rgba(255, 0, 0)'}
+    properties = {'border-width' => '22%', 'border-color' => 'rgba(255, 0, 0)', 'border-style' => 'solid'}
     combined = create_shorthand(properties)
-    assert_equal '22% rgba(255, 0, 0);', combined['border']
+    assert_equal '22% solid rgba(255, 0, 0);', combined['border']
     assert_equal '', combined['border-width']
+    assert_equal '', combined['border-color']
+    assert_equal '', combined['border-style']
 
     properties = {
-      'border-top-style' => 'none', 'border-right-style' => 'none', 'border-bottom-style' => 'none',
+      'border-top-style' => 'none',
+      'border-right-style' => 'none',
+      'border-bottom-style' => 'none',
       'border-left-style' => 'none'
     }
     combined = create_shorthand(properties)
-    assert_equal 'none;', combined['border']
+    assert_equal '', combined['border']
+    assert_equal 'none;', combined['border-style']
 
     properties = {
       'border-top-color' => '#bada55', 'border-right-color' => '#000000', 'border-bottom-color' => '#ffffff',

--- a/test/test_rule_set_creating_shorthand.rb
+++ b/test/test_rule_set_creating_shorthand.rb
@@ -11,9 +11,7 @@ class RuleSetCreatingShorthandTests < Minitest::Test
   end
 
   def test_border_width
-    combined = create_shorthand(
-      'border-width': '1px',
-    )
+    combined = create_shorthand('border-width': '1px')
 
     assert_equal '', combined['border']
     assert_equal '1px;', combined['border-width']
@@ -34,7 +32,9 @@ class RuleSetCreatingShorthandTests < Minitest::Test
   # Border shorthand
   def test_combining_borders_into_shorthand
     properties = {
-      'border-top-width' => 'auto', 'border-right-width' => 'thin', 'border-bottom-width' => 'auto',
+      'border-top-width' => 'auto',
+      'border-right-width' => 'thin',
+      'border-bottom-width' => 'auto',
       'border-left-width' => '0px'
     }
 
@@ -53,7 +53,11 @@ class RuleSetCreatingShorthandTests < Minitest::Test
 
     assert_equal '', combined['border-width']
 
-    properties = {'border-width' => '22%', 'border-color' => 'rgba(255, 0, 0)', 'border-style' => 'solid'}
+    properties = {
+      'border-width' => '22%',
+      'border-color' => 'rgba(255, 0, 0)',
+      'border-style' => 'solid'
+    }
     combined = create_shorthand(properties)
     assert_equal '22% solid rgba(255, 0, 0);', combined['border']
     assert_equal '', combined['border-width']
@@ -71,7 +75,9 @@ class RuleSetCreatingShorthandTests < Minitest::Test
     assert_equal 'none;', combined['border-style']
 
     properties = {
-      'border-top-color' => '#bada55', 'border-right-color' => '#000000', 'border-bottom-color' => '#ffffff',
+      'border-top-color' => '#bada55',
+      'border-right-color' => '#000000',
+      'border-bottom-color' => '#ffffff',
       'border-left-color' => '#ff0000'
     }
     combined = create_shorthand(properties)


### PR DESCRIPTION
When having `border-width: 1px` and `border-color: black` but no `border-style` it would combine to an invalid, see https://codepen.io/dorianmariefr/pen/qBPqLZM for instance

Now it doesn't combine the properties if the three (width/color/style) are not present

### Context

I encountered this when doing `@apply border border-black` in tailwindcss and having it compiled by premailer for my emails, the border would not appear

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
