### PR TITLE
Return the property value in an empty value rule set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+ * Improve exception message for missing value [#131](https://github.com/premailer/css_parser/pull/131)
+
 ### Version 1.11.0
 
  * Do not combine border styles width/color/style are not all present

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -93,6 +93,8 @@ module CssParser
         else
           declarations[property] = Value.new(value)
         end
+      rescue ArgumentError => e
+        raise e.exception, "#{property} #{e.message}"
       end
       alias add_declaration! []=
 

--- a/test/rule_set/declarations/test_value.rb
+++ b/test/rule_set/declarations/test_value.rb
@@ -102,6 +102,12 @@ class RuleSetProperyTest < Minitest::Test
 
       assert_equal true, CssParser::RuleSet::Declarations::Value.new('value').value.frozen?
     end
+
+    it 'raises an exception when the value is empty' do
+      assert_raises ArgumentError do
+        CssParser::RuleSet::Declarations::Value.new
+      end
+    end
   end
 
   describe '#to_s' do

--- a/test/rule_set/test_declarations.rb
+++ b/test/rule_set/test_declarations.rb
@@ -68,6 +68,14 @@ class RuleSetDeclarationsTest < Minitest::Test
 
       assert_equal declarations.method(:[]=), declarations.method(:add_declaration!)
     end
+
+    it 'raises an exception including the property when the value is empty' do
+      declarations = CssParser::RuleSet::Declarations.new
+
+      assert_raises ArgumentError, 'foo value is empty' do
+        declarations['foo'] = '!important'
+      end
+    end
   end
 
   describe '#[]' do


### PR DESCRIPTION
Include the property in the ArgumentError returned by an empty value.

Spent several hours trying to trace this, having the property in the exception would have helped immensely.

Related #125

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
