### PR TITLE
Allow rule set argument exceptions to be muted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+ * `:rule_set_exceptions` option added [#132](https://github.com/premailer/css_parser/pull/132)
+
 ### Version 1.11.0
 
  * Do not combine border styles width/color/style are not all present

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -39,6 +39,7 @@ module CssParser
       @options = {absolute_paths: false,
                   import: true,
                   io_exceptions: true,
+                  rule_set_exceptions: true,
                   capture_offsets: false}.merge(options)
 
       # array of RuleSets
@@ -167,6 +168,8 @@ module CssParser
     def add_rule!(selectors, declarations, media_types = :all)
       rule_set = RuleSet.new(selectors, declarations)
       add_rule_set!(rule_set, media_types)
+    rescue ArgumentError => e
+      raise e if @options[:rule_set_exceptions]
     end
 
     # Add a CSS rule by setting the +selectors+, +declarations+, +filename+, +offset+ and +media_types+.

--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -204,4 +204,16 @@ class CssParserLoadingTests < Minitest::Test
 
     cp_without_exceptions.load_uri!("#{@uri_base}/no-exist.xyz")
   end
+
+  def test_rule_set_argument_exceptions
+    cp_with_exceptions = Parser.new(rule_set_exceptions: true)
+
+    assert_raises ArgumentError, 'background-color value is empty' do
+      cp_with_exceptions.add_rule!('body', 'background-color: !important')
+    end
+
+    cp_without_exceptions = Parser.new(rule_set_exceptions: false)
+
+    cp_without_exceptions.add_rule!('body', 'background-color: !important')
+  end
 end


### PR DESCRIPTION
Add a new option `rule_set_exceptions` to silently swallow ArgumentErrors generated from RuleSet.

Related #125 

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
