### PR TITLE
Fix parsing space-less media-features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+ * Fix parsing space-less media query features like `@media(width:123px)` [#141](https://github.com/premailer/css_parser/pull/141)
+
 ### Version v1.15.0
 
  * Fix parsing background shorthands in ruby 3.2 [#140](https://github.com/premailer/css_parser/pull/140)

--- a/test/test_css_parser_media_types.rb
+++ b/test/test_css_parser_media_types.rb
@@ -46,6 +46,25 @@ class CssParserMediaTypesTests < Minitest::Test
     assert_equal 'color: blue;', @cp.find_by_selector('body', 'print and resolution > 90dpi'.to_sym).join(' ')
   end
 
+  def test_with_parenthesized_media_features
+    @cp.add_block!(<<-CSS)
+      body { color: black }
+      @media(prefers-color-scheme: dark) {
+        body { color: white }
+      }
+      @media(min-width: 500px) {
+        body { color: blue }
+      }
+      @media screen and (width > 500px) {
+        body { color: red }
+      }
+    CSS
+    assert_equal [:all, :'(prefers-color-scheme: dark)', :'(min-width: 500px)', :'screen and (width > 500px)'], @cp.rules_by_media_query.keys
+    assert_equal 'color: white;', @cp.find_by_selector('body', :'(prefers-color-scheme: dark)').join(' ')
+    assert_equal 'color: blue;', @cp.find_by_selector('body', :'(min-width: 500px)').join(' ')
+    assert_equal 'color: red;', @cp.find_by_selector('body', :'screen and (width > 500px)').join(' ')
+  end
+
   def test_finding_by_multiple_media_types
     @cp.add_block!(<<-CSS)
       @media print {


### PR DESCRIPTION
Previously, `@media (width:500px)` would be successfully parsed, but not `@media(width:500px)` - it would result in  `@media(width:500px)` as a single token, effectively ignoring the `media:500px` media-feature and assigning all the rules in that media query to the `:all` namespace.

This tokenizes `(` and `)` separately ... which naively seems ok to me and passes all the tests, but I'd confess to being a little nervous how it behaves with real-world CSS.

Fixes #139

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
