### PR TITLE
chore: Adds Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'jruby-head']
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "jruby-head"]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: "3.0"
           bundler-cache: true
 
       - run: bundle exec rake rubocop


### PR DESCRIPTION
Why and what is being done.

## Pre-Merge Checklist
- [ ] CHANGELOG.md updated with short summary
