### PR TITLE
Added `user_agent` as an option to Parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+ * Added `user_agent` as an option to Parser [#146](https://github.com/premailer/css_parser/pull/146)
+
 ### Version v1.16.0
 
  * Fix parsing space-less media query features like `@media(width:123px)` [#141](https://github.com/premailer/css_parser/pull/141)

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -40,7 +40,7 @@ module CssParser
                   io_exceptions: true,
                   rule_set_exceptions: true,
                   capture_offsets: false,
-                  user_agent: "Ruby CSS Parser/#{CssParser::VERSION} (https://github.com/premailer/css_parser)"}.merge(options)
+                  user_agent: USER_AGENT}.merge(options)
 
       # array of RuleSets
       @rules = []

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -16,8 +16,6 @@ module CssParser
   # [<tt>import</tt>] Follow <tt>@import</tt> rules. Boolean, default is <tt>true</tt>.
   # [<tt>io_exceptions</tt>] Throw an exception if a link can not be found. Boolean, default is <tt>true</tt>.
   class Parser
-    USER_AGENT = "Ruby CSS Parser/#{CssParser::VERSION} (https://github.com/premailer/css_parser)"
-
     STRIP_CSS_COMMENTS_RX = %r{/\*.*?\*/}m.freeze
     STRIP_HTML_COMMENTS_RX = /<!--|-->/m.freeze
 
@@ -40,7 +38,8 @@ module CssParser
                   import: true,
                   io_exceptions: true,
                   rule_set_exceptions: true,
-                  capture_offsets: false}.merge(options)
+                  capture_offsets: false,
+                  user_agent: "Ruby CSS Parser/#{CssParser::VERSION} (https://github.com/premailer/css_parser)"}.merge(options)
 
       # array of RuleSets
       @rules = []
@@ -597,7 +596,7 @@ module CssParser
             http = Net::HTTP.new(uri.host, uri.port)
           end
 
-          res = http.get(uri.request_uri, {'User-Agent' => USER_AGENT, 'Accept-Encoding' => 'gzip'})
+          res = http.get(uri.request_uri, {'User-Agent' => @options[:user_agent], 'Accept-Encoding' => 'gzip'})
           src = res.body
           charset = res.respond_to?(:charset) ? res.encoding : 'utf-8'
 

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -16,6 +16,7 @@ module CssParser
   # [<tt>import</tt>] Follow <tt>@import</tt> rules. Boolean, default is <tt>true</tt>.
   # [<tt>io_exceptions</tt>] Throw an exception if a link can not be found. Boolean, default is <tt>true</tt>.
   class Parser
+    USER_AGENT = "Ruby CSS Parser/#{CssParser::VERSION} (https://github.com/premailer/css_parser)"
     STRIP_CSS_COMMENTS_RX = %r{/\*.*?\*/}m.freeze
     STRIP_HTML_COMMENTS_RX = /<!--|-->/m.freeze
 


### PR DESCRIPTION
Added `user_agent` as an option to Parser to allow manually setting the user agent (closes #145).

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
