### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/css_parser.gemspec
+++ b/css_parser.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new name, CssParser::VERSION do |s|
   s.metadata['changelog_uri'] = 'https://github.com/premailer/css_parser/blob/master/CHANGELOG.md'
   s.metadata['source_code_uri'] = 'https://github.com/premailer/css_parser'
   s.metadata['bug_tracker_uri'] = 'https://github.com/premailer/css_parser/issues'
+  s.metadata['rubygems_mfa_required'] = 'true'
 
   s.add_runtime_dependency 'addressable'
 


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/

Why and what is being done.

## Pre-Merge Checklist
- [x] ~CHANGELOG.md updated with short summary~
