### PR TITLE
Use File.read instead of IO.read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+ * Improve security by using `File.read` instead of `IO.read` [#148](https://github.com/premailer/css_parser/pull/148)
+
 ### Version v1.17.0
 
  * Added `user_agent` as an option to Parser [#146](https://github.com/premailer/css_parser/pull/146)

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -486,7 +486,7 @@ module CssParser
       return unless File.readable?(file_name)
       return unless circular_reference_check(file_name)
 
-      src = IO.read(file_name)
+      src = File.read(file_name)
 
       opts[:filename] = file_name if opts[:capture_offsets]
       opts[:base_dir] = File.dirname(file_name)


### PR DESCRIPTION
If argument starts with a pipe character (`'|'`) and the receiver is the `IO` class, a subprocess is created in the same way as `Kernel#open`, and its output is returned. `Kernel#open` may allow unintentional command injection, which is the reason these `IO` methods are a security risk. Consider to use `File.read` to disable the behavior of subprocess invocation.

Ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/IoMethods

Why and what is being done.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
