### PR TITLE
fix: PR number typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Version v1.17.1
 
- * Improve security by using `File.read` instead of `IO.read` [#148](https://github.com/premailer/css_parser/pull/148)
+ * Improve security by using `File.read` instead of `IO.read` [#149](https://github.com/premailer/css_parser/pull/149)
 
 ### Version v1.17.0
 


### PR DESCRIPTION
I corrected a typo in the contents of CHANGELOG.md for version 1.17.1.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
