### PR TITLE
V2 rule set declaration parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,9 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Style/AccessModifierDeclarations:
+  Enabled: false
+
 Style/AndOr:
   Enabled: false
 

--- a/css_parser.gemspec
+++ b/css_parser.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new name, CssParser::VERSION do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.metadata['changelog_uri'] = 'https://github.com/premailer/css_parser/blob/master/CHANGELOG.md'
+  s.metadata['documentation_uri'] = "https://www.rubydoc.info/gems/css_parser/#{s.version}"
   s.metadata['source_code_uri'] = 'https://github.com/premailer/css_parser'
   s.metadata['bug_tracker_uri'] = 'https://github.com/premailer/css_parser/issues'
   s.metadata['rubygems_mfa_required'] = 'true'

--- a/lib/css_parser/regexps.rb
+++ b/lib/css_parser/regexps.rb
@@ -45,7 +45,6 @@ module CssParser
   RE_SINGLE_BACKGROUND_SIZE = /#{RE_LENGTH_OR_PERCENTAGE}|auto|cover|contain|initial|inherit/i.freeze
   RE_BACKGROUND_POSITION = /#{RE_SINGLE_BACKGROUND_POSITION}\s+#{RE_SINGLE_BACKGROUND_POSITION}|#{RE_SINGLE_BACKGROUND_POSITION}/.freeze
   RE_BACKGROUND_SIZE = %r{\s*/\s*(#{RE_SINGLE_BACKGROUND_SIZE}\s+#{RE_SINGLE_BACKGROUND_SIZE}|#{RE_SINGLE_BACKGROUND_SIZE})}.freeze
-  FONT_UNITS_RX = /((x+-)*small|medium|larger*|auto|inherit|([0-9]+|[0-9]*\.[0-9]+)(e[mx]+|px|[cm]+m|p[tc+]|in|%)*)/i.freeze
   RE_BORDER_STYLE = /(\s*^)?(none|hidden|dotted|dashed|solid|double|dot-dash|dot-dot-dash|wave|groove|ridge|inset|outset)(\s*$)?/imx.freeze
   RE_BORDER_UNITS = Regexp.union(BOX_MODEL_UNITS_RX, /(thin|medium|thick)/i)
 

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'set'
 
 module CssParser
   class RuleSet
@@ -203,6 +204,85 @@ module CssParser
       end
     end
 
+    class FontScanner
+      FONT_STYLES = Set.new(['normal', 'italic', 'oblique', 'inherit'])
+      FONT_VARIANTS = Set.new(['normal', 'small-caps', 'inherit'])
+      FONT_WEIGHTS = Set.new(
+        [
+          'normal', 'bold', 'bolder', 'lighter',
+          '100', '200', '300', '400', '500', '600', '700', '800', '900',
+          'inherit'
+        ]
+      )
+      ABSOLUTE_SIZES = Set.new(
+        ['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']
+      )
+      RELATIVE_SIZES = Set.new(['smaller', 'larger'])
+
+      attr_reader :current, :pos, :tokens
+
+      def initialize(tokens)
+        @token_scanner = Crass::TokenScanner.new(tokens)
+      end
+
+      def peek = @token_scanner.peek
+      def consume = @token_scanner.consume
+      def collect(&block) = @token_scanner.collect(&block)
+
+      private def consume_iden_str(value)
+        consume if peek[:node] == :ident && peek[:value] == value
+      end
+
+      private def consume_iden_set(set)
+        consume if peek[:node] == :ident && set.member?(peek[:value])
+      end
+
+      private def consume_type(type)
+        consume if peek[:node] == type
+      end
+
+      def consume_font_style = consume_iden_set(FONT_STYLES)
+      def consume_font_variant = consume_iden_set(FONT_VARIANTS)
+      def consume_font_weight = consume_iden_set(FONT_WEIGHTS) || consume_type(:number)
+      def consume_absulute_size = consume_iden_set(ABSOLUTE_SIZES)
+      def consume_relative_size = consume_iden_set(RELATIVE_SIZES)
+      def consume_length = consume_type(:dimension)
+      def consume_percentage = consume_type(:percentage)
+      def consume_number = consume_type(:percentage)
+      def consume_inherit = consume_iden_str('inherit')
+      def consume_normal = consume_iden_str('normal')
+
+      def consume_font_style_variant_weight
+        consume_font_style || consume_font_variant || consume_font_weight
+      end
+
+      def consume_font_size
+        consume_absulute_size ||
+          consume_relative_size ||
+          consume_length ||
+          consume_percentage ||
+          consume_inherit
+      end
+
+      def consume_line_height
+        consume_normal ||
+          consume_number ||
+          consume_length ||
+          consume_percentage ||
+          consume_inherit
+      end
+
+      def consume_system_fonts
+        consume_iden_str('caption') ||
+          consume_iden_str('icon') ||
+          consume_iden_str('menu') ||
+          consume_iden_str('message-box') ||
+          consume_iden_str('small-caption') ||
+          consume_iden_str('status-bar') ||
+          consume_inherit
+      end
+    end
+
     # Convert shorthand font declarations (e.g. <tt>font: 300 italic 11px/14px verdana, helvetica, sans-serif;</tt>)
     # into their constituent parts.
     def expand_font_shorthand! # :nodoc:
@@ -216,41 +296,45 @@ module CssParser
         'font-size' => 'normal',
         'line-height' => 'normal'
       }
+      tokens = Crass::Tokenizer
+               .tokenize(declaration.value.dup)
+               .reject { _1[:node] == :whitespace }
+      scanner = FontScanner.new(tokens)
 
-      value = declaration.value.dup
-      value.gsub!(%r{/\s+}, '/') # handle spaces between font size and height shorthand (e.g. 14px/ 16px)
+      if scanner.consume_system_fonts
+        # nothing we can do with system fonts
+        return
+      end
 
-      in_fonts = false
-
-      matches = value.scan(/"(?:.*[^"])"|'(?:.*[^'])'|(?:\w[^ ,]+)/)
-      matches.each do |m|
-        m.strip!
-        m.gsub!(/;$/, '')
-
-        if in_fonts
-          if font_props.key?('font-family')
-            font_props['font-family'] += ", #{m}"
-          else
-            font_props['font-family'] = m
-          end
-        elsif m =~ /normal|inherit/i
-          ['font-style', 'font-weight', 'font-variant'].each do |font_prop|
-            font_props[font_prop] ||= m
-          end
-        elsif m =~ /italic|oblique/i
-          font_props['font-style'] = m
-        elsif m =~ /small-caps/i
-          font_props['font-variant'] = m
-        elsif m =~ /[1-9]00$|bold|bolder|lighter/i
-          font_props['font-weight'] = m
-        elsif m =~ CssParser::FONT_UNITS_RX
-          if m.include?('/')
-            font_props['font-size'], font_props['line-height'] = m.split('/', 2)
-          else
-            font_props['font-size'] = m
-          end
-          in_fonts = true
+      while (token = scanner.consume_font_style_variant_weight)
+        if FontScanner::FONT_STYLES.member?(token[:value])
+          font_props['font-style'] = token[:value]
         end
+        if FontScanner::FONT_VARIANTS.member?(token[:value])
+          font_props['font-variant'] = token[:value]
+        end
+        # we use raw from font wights since it include numbers
+        if FontScanner::FONT_WEIGHTS.member?(token[:raw])
+          font_props['font-weight'] = token[:raw]
+        end
+      end
+
+      font_size = scanner.consume_font_size
+      font_props['font-size'] = font_size[:raw]
+
+      if scanner.peek[:node] == :delim && scanner.peek[:value] == '/'
+        scanner.consume
+        line_height = scanner.consume_line_height
+        font_props['line-height'] = line_height[:raw]
+      end
+
+      rest = scanner.collect do
+        while scanner.consume
+          # nothing, just collect the rest
+        end
+      end
+      if rest.any?
+        font_props['font-family'] = Crass::Parser.stringify(rest)
       end
 
       declarations.replace_declaration!('font', font_props, preserve_importance: true)

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -426,27 +426,15 @@ module CssParser
     end
 
     def parse_declarations!(block) # :nodoc:
-      if block.is_a? Declarations
+      case block
+      when nil
+        self.declarations = Declarations.new
+      when Declarations
         self.declarations = block
-        return
-      end
-
-      self.declarations = Declarations.new
-
-      return unless block
-
-      continuation = nil
-      block.split(/[;$]+/m).each do |decs|
-        decs = (continuation ? continuation + decs : decs)
-        if decs =~ /\([^)]*\Z/ # if it has an unmatched parenthesis
-          continuation = "#{decs};"
-        elsif (matches = decs.match(/\s*(.[^:]*)\s*:\s*(?m:(.+))(?:;?\s*\Z)/i))
-          # skip end_of_declaration
-          property = matches[1]
-          value = matches[2]
-          add_declaration!(property, value)
-          continuation = nil
-        end
+      when String
+        Crass.parse_properties(block)
+             .then { ParserFx.create_declaration_from_properties(_1) }
+             .then { self.declarations = _1 }
       end
     end
 

--- a/lib/css_parser/rule_set/declarations.rb
+++ b/lib/css_parser/rule_set/declarations.rb
@@ -100,7 +100,7 @@ module CssParser
       alias remove_declaration! delete
 
       # Replace CSS property with multiple declarations
-      # @param [#to_s] property property name to be replaces
+      # @param [#to_s] replacing_property property name to be replaces
       # @param [Hash<String => [String, Value]>] replacements hash with properties to replace with
       #
       # This function is used to expand and collapse css properties that has

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -187,26 +187,6 @@ class CssParserTests < Minitest::Test
     assert_equal ".specs {font-family:Helvetica;font-weight:bold;font-style:italic;color:#008CA8;font-size:1.4em;list-style-image:url('http://www.example.org/directory/images/bullet.gif');}", converted_css
   end
 
-  def test_ruleset_with_braces
-    # parser = Parser.new
-    # parser.add_block!("div { background-color: black !important; }")
-    # parser.add_block!("div { background-color: red; }")
-    #
-    # rulesets = []
-    #
-    # parser['div'].each do |declaration|
-    #   rulesets << RuleSet.new(selectors: 'div', block: declaration)
-    # end
-    #
-    # merged = CssParser.merge(rulesets)
-    #
-    # result: # merged.to_s => "{ background-color: black !important; }"
-
-    new_rule = RuleSet.new(selectors: 'div', block: "{ background-color: black !important; }")
-
-    assert_equal 'div { background-color: black !important; }', new_rule.to_s
-  end
-
   def test_content_with_data
     rule = RuleSet.new(selectors: 'div', block: 'content: url(data:image/png;base64,LOTSOFSTUFF)')
     assert_includes rule.to_s, "image/png;base64,LOTSOFSTUFF"

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -208,7 +208,7 @@ class CssParserTests < Minitest::Test
   end
 
   def test_content_with_data
-    rule = RuleSet.new(selectors: 'div', block: '{content: url(data:image/png;base64,LOTSOFSTUFF)}')
+    rule = RuleSet.new(selectors: 'div', block: 'content: url(data:image/png;base64,LOTSOFSTUFF)')
     assert_includes rule.to_s, "image/png;base64,LOTSOFSTUFF"
   end
 
@@ -225,16 +225,5 @@ class CssParserTests < Minitest::Test
       assert_equal 'body', sel
       assert_equal 'color: black;', desc
     end
-  end
-
-  def test_catching_argument_exceptions_for_add_rule
-    cp_with_exceptions = Parser.new(rule_set_exceptions: true)
-    error = assert_raises CssParser::EmptyValueError do
-      cp_with_exceptions.add_rule!(selectors: 'body', block: 'background-color: !important')
-    end
-    assert_equal error.message, 'background-color value is empty'
-
-    cp_without_exceptions = Parser.new(rule_set_exceptions: false)
-    cp_without_exceptions.add_rule!(selectors: 'body', block: 'background-color: !important')
   end
 end

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -71,20 +71,26 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     ['em', 'ex', 'in', 'px', 'pt', 'pc', '%'].each do |unit|
       shorthand = "font: 300 italic 11.25#{unit}/14px verdana, helvetica, sans-serif;"
       declarations = expand_declarations(shorthand)
-      assert_equal("11.25#{unit}", declarations['font-size'])
+      assert_equal("11.25#{unit}", declarations['font-size'], shorthand)
     end
 
     ['smaller', 'small', 'medium', 'large', 'x-large'].each do |unit|
       shorthand = "font: 300 italic #{unit}/14px verdana, helvetica, sans-serif;"
       declarations = expand_declarations(shorthand)
-      assert_equal(unit, declarations['font-size'])
+      assert_equal(unit, declarations['font-size'], shorthand)
     end
+  end
+
+  def test_font_with_comments_and_spaces
+    shorthand = "font: 300 /* HI */   italic  \t\t   12px  sans-serif;"
+    declarations = expand_declarations(shorthand)
+    assert_equal("12px", declarations['font-size'])
   end
 
   def test_getting_font_families_from_shorthand
     shorthand = "font: 300 italic 12px/14px \"Helvetica-Neue-Light 45\", 'verdana', helvetica, sans-serif;"
     declarations = expand_declarations(shorthand)
-    assert_equal("\"Helvetica-Neue-Light 45\", 'verdana', helvetica, sans-serif", declarations['font-family'])
+    assert_equal("\"Helvetica-Neue-Light 45\",'verdana',helvetica,sans-serif", declarations['font-family'])
   end
 
   def test_getting_font_weight_from_shorthand
@@ -95,8 +101,10 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     end
 
     # ensure normal is the default state
-    ['font: normal italic 12px sans-serif;', 'font: italic 12px sans-serif;',
-     'font: small-caps normal 12px sans-serif;', 'font: 12px/16px sans-serif;'].each do |shorthand|
+    ['font: normal italic 12px sans-serif;',
+     'font: italic 12px sans-serif;',
+     'font: small-caps normal 12px sans-serif;',
+     'font: 12px/16px sans-serif;'].each do |shorthand|
       declarations = expand_declarations(shorthand)
       assert_equal('normal', declarations['font-weight'], shorthand)
     end
@@ -110,8 +118,11 @@ class RuleSetExpandingShorthandTests < Minitest::Test
 
   def test_getting_font_variant_from_shorthand_ensure_normal_is_the_default_state
     [
-      'font: normal italic 12px sans-serif;', 'font: italic 12px sans-serif;',
-      'font: normal 12px sans-serif;', 'font: 12px/16px sans-serif;'
+      'font: normal large sans-serif;',
+      'font: normal italic 12px sans-serif;',
+      'font: italic 12px sans-serif;',
+      'font: normal 12px sans-serif;',
+      'font: 12px/16px sans-serif;'
     ].each do |shorthand|
       declarations = expand_declarations(shorthand)
       assert_equal('normal', declarations['font-variant'], shorthand)
@@ -126,8 +137,10 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     end
 
     # ensure normal is the default state
-    ['font: normal bold 12px sans-serif;', 'font: small-caps 12px sans-serif;',
-     'font: normal 12px sans-serif;', 'font: 12px/16px sans-serif;'].each do |shorthand|
+    ['font: normal bold 12px sans-serif;',
+     'font: small-caps 12px sans-serif;',
+     'font: normal 12px sans-serif;',
+     'font: 12px/16px sans-serif;'].each do |shorthand|
       declarations = expand_declarations(shorthand)
       assert_equal('normal', declarations['font-style'], shorthand)
     end
@@ -141,8 +154,10 @@ class RuleSetExpandingShorthandTests < Minitest::Test
     end
 
     # ensure normal is the default state
-    ['font: normal bold 12px sans-serif;', 'font: small-caps 12px sans-serif;',
-     'font: normal 12px sans-serif;', 'font: 12px sans-serif;'].each do |shorthand|
+    ['font: normal bold 12px sans-serif;',
+     'font: small-caps 12px sans-serif;',
+     'font: normal 12px sans-serif;',
+     'font: 12px sans-serif;'].each do |shorthand|
       declarations = expand_declarations(shorthand)
       assert_equal('normal', declarations['line-height'], shorthand)
     end
@@ -153,6 +168,15 @@ class RuleSetExpandingShorthandTests < Minitest::Test
       shorthand = "font: 300 italic 12px/ 0.25#{unit} verdana, helvetica, sans-serif;"
       declarations = expand_declarations(shorthand)
       assert_equal("0.25#{unit}", declarations['line-height'])
+    end
+  end
+
+  def test_expands_nothing_using_system_fonts
+    %w[caption icon menu message-box small-caption status-bar].each do |system_font|
+      shorthand = "font: #{system_font}"
+      declarations = expand_declarations(shorthand)
+      assert_equal(["font"], declarations.keys)
+      assert_equal(system_font, declarations['font'])
     end
   end
 

--- a/test/test_rule_set_expanding_shorthand.rb
+++ b/test/test_rule_set_expanding_shorthand.rb
@@ -74,7 +74,7 @@ class RuleSetExpandingShorthandTests < Minitest::Test
       assert_equal("11.25#{unit}", declarations['font-size'])
     end
 
-    ['smaller', 'small', 'medium', 'large', 'x-large', 'auto'].each do |unit|
+    ['smaller', 'small', 'medium', 'large', 'x-large'].each do |unit|
       shorthand = "font: 300 italic #{unit}/14px verdana, helvetica, sans-serif;"
       declarations = expand_declarations(shorthand)
       assert_equal(unit, declarations['font-size'])


### PR DESCRIPTION
I refactored expand_font_shorthand. I think its better. I think I want to do the same for all the other expand features. When I do that I think we can remove more of the regexes. Would you like that?

I am trying not to touch test too much to keep all existing features working.

Should I maybe add some notes into changelog that some features are removed?
