### PR TITLE
Improve parse_declarations! performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * RuleSet initialize now takes keyword argument, positional arguments are still supported but deprecated
 * Removed OffsetAwareRuleSet, it's a RuleSet with optional attributes filename and offset
 * Improved performance of block parsing by using StringScanner
+* Improve `RuleSet#parse_declarations!` performance by using substring search istead of regexps
 
 ### Version v1.18.0
 

--- a/test/test_rule_set.rb
+++ b/test/test_rule_set.rb
@@ -78,6 +78,19 @@ class RuleSetTests < Minitest::Test
     assert_equal('no-repeat;', rs['background-repeat'])
   end
 
+  def test_each_declaration_with_newlines
+    expected = Set[
+      {property: 'background-image', value: 'url(foo;bar)', is_important: false},
+      {property: 'font-weight', value: 'bold', is_important: true},
+    ]
+    rs = RuleSet.new(block: "background-image\n:\nurl(foo;bar);\n\n\n\n\n;;font-weight\n\n\n:bold\n\n\n!important")
+    actual = Set.new
+    rs.each_declaration do |prop, val, imp|
+      actual << {property: prop, value: val, is_important: imp}
+    end
+    assert_equal(expected, actual)
+  end
+
   def test_selector_sanitization
     selectors = "h1, h2,\nh3 "
     rs = RuleSet.new(selectors: selectors, block: "color: #fff;")


### PR DESCRIPTION
This PR replaces regexp-matching code in `parse_declarations!` with equivalent substring lookup using `.split(&block)` and `.index`.

On our benchmarks this shows a 10% improvement in performance measured for _overall_ `add_rule!` / `add_block!`. So, quite a significant one.

## Pre-Merge Checklist

- [x] CHANGELOG.md updated with short summary
