### PR TITLE
Use StringScanner instead of String#scan to improve block parsing performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Deprecate `add_rule!` (positional arguments)and `add_rule_with_offsets!` for `add_rule!` (keyword argument)
 * RuleSet initialize now takes keyword argument, positional arguments are still supported but deprecated
 * Removed OffsetAwareRuleSet, it's a RuleSet with optional attributes filename and offset
+* Improved performance of block parsing by using StringScanner
 
 ### Version v1.18.0
 


### PR DESCRIPTION
This PR replaces `scan` in `parse_block_into_rule_sets!` with `StringScanner` - a more performant API for tokenizing strings.

Tenderlove had a [post](https://tenderlovemaking.com/2023/09/02/fast-tokenizers-with-stringscanner/) last year about this.

On our benchmarks this shows a **18%** improvement in performance measured for overall `add_block!`. The code has been in production for around 3 years now, unfortunately making changes public takes additional effort.

## Pre-Merge Checklist
- [x] CHANGELOG.md updated with short summary
