### PR TITLE
Fix error when parsing values consisting of `!important` only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Removed OffsetAwareRuleSet, it's a RuleSet with optional attributes filename and offset
 * Improved performance of block parsing by using StringScanner
 * Improve `RuleSet#parse_declarations!` performance by using substring search istead of regexps
+* Fix error when parsing values consisting of `!important` only
 
 ### Version v1.18.0
 

--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -31,6 +31,7 @@ module CssParser
     SEMICOLON = ';'.freeze
     LPAREN = '('.freeze
     RPAREN = ')'.freeze
+    IMPORTANT = '!important'.freeze
     class Declarations
       class Value
         attr_reader :value
@@ -667,7 +668,7 @@ module CssParser
         value = decs[(colon + 1)..]
         property.strip!
         value.strip!
-        next if property.empty? || value.empty?
+        next if property.empty? || value.empty? || value.casecmp?(IMPORTANT)
 
         add_declaration!(property, value)
         continuation = nil

--- a/test/test_css_parser_misc.rb
+++ b/test/test_css_parser_misc.rb
@@ -227,47 +227,58 @@ class CssParserTests < Minitest::Test
     end
   end
 
-  def test_catching_argument_exceptions_for_add_rule
-    cp_with_exceptions = Parser.new(rule_set_exceptions: true)
-    assert_raises ArgumentError, 'background-color value is empty' do
-      cp_with_exceptions.add_rule!(selectors: 'body', block: 'background-color: !important')
-    end
+  def with_value_exception(&block)
+    # Raise synthetic exception to test error handling because there is no known way to cause it naturally
+    CssParser::RuleSet::Declarations::Value.stub :new, -> { raise ArgumentError.new, 'stub' }, &block
+  end
 
-    cp_without_exceptions = Parser.new(rule_set_exceptions: false)
-    cp_without_exceptions.add_rule!(selectors: 'body', block: 'background-color: !important')
+  def test_catching_argument_exceptions_for_add_rule
+    with_value_exception do
+      cp_with_exceptions = Parser.new(rule_set_exceptions: true)
+      assert_raises ArgumentError, 'stub' do
+        cp_with_exceptions.add_rule!(selectors: 'body', block: 'background-color: blue')
+      end
+
+      cp_without_exceptions = Parser.new(rule_set_exceptions: false)
+      cp_without_exceptions.add_rule!(selectors: 'body', block: 'background-color: blue')
+    end
   end
 
   def test_catching_argument_exceptions_for_add_rule_positional
-    cp_with_exceptions = Parser.new(rule_set_exceptions: true)
+    with_value_exception do
+      cp_with_exceptions = Parser.new(rule_set_exceptions: true)
 
-    assert_raises ArgumentError, 'background-color value is empty' do
+      assert_raises ArgumentError, 'stub' do
+        _, err = capture_io do
+          cp_with_exceptions.add_rule!('body', 'background-color: blue')
+        end
+        assert_includes err, "DEPRECATION"
+      end
+
+      cp_without_exceptions = Parser.new(rule_set_exceptions: false)
       _, err = capture_io do
-        cp_with_exceptions.add_rule!('body', 'background-color: !important')
+        cp_without_exceptions.add_rule!('body', 'background-color: blue')
       end
       assert_includes err, "DEPRECATION"
     end
-
-    cp_without_exceptions = Parser.new(rule_set_exceptions: false)
-    _, err = capture_io do
-      cp_without_exceptions.add_rule!('body', 'background-color: !important')
-    end
-    assert_includes err, "DEPRECATION"
   end
 
   def test_catching_argument_exceptions_for_add_rule_with_offsets
-    cp_with_exceptions = Parser.new(capture_offsets: true, rule_set_exceptions: true)
+    with_value_exception do
+      cp_with_exceptions = Parser.new(capture_offsets: true, rule_set_exceptions: true)
 
-    assert_raises ArgumentError, 'background-color value is empty' do
+      assert_raises ArgumentError, 'stub' do
+        _, err = capture_io do
+          cp_with_exceptions.add_rule_with_offsets!('body', 'background-color: blue', 'inline', 1)
+        end
+        assert_includes err, "DEPRECATION"
+      end
+
+      cp_without_exceptions = Parser.new(capture_offsets: true, rule_set_exceptions: false)
       _, err = capture_io do
-        cp_with_exceptions.add_rule_with_offsets!('body', 'background-color: !important', 'inline', 1)
+        cp_without_exceptions.add_rule_with_offsets!('body', 'background-color: blue', 'inline', 1)
       end
       assert_includes err, "DEPRECATION"
     end
-
-    cp_without_exceptions = Parser.new(capture_offsets: true, rule_set_exceptions: false)
-    _, err = capture_io do
-      cp_without_exceptions.add_rule_with_offsets!('body', 'background-color: !important', 'inline', 1)
-    end
-    assert_includes err, "DEPRECATION"
   end
 end

--- a/test/test_rule_set.rb
+++ b/test/test_rule_set.rb
@@ -122,6 +122,12 @@ class RuleSetTests < Minitest::Test
     end
   end
 
+  def test_important_without_value
+    declarations = 'color: !important; background-color: #fff'
+    rs = RuleSet.new(selectors: '#content p, a', block: declarations)
+    assert_equal('background-color: #fff;', rs.declarations_to_s)
+  end
+
   def test_not_raised_issue68
     ok = true
     begin


### PR DESCRIPTION
I haven't found a good justification for raising the error, and it helps a lot when parsing 3rd party CSS. It would still be raised when manually creating the declarations, and not parsing a block of CSS.

The performance impact is not noticable in my benchmarks... i also have a version that optimizes adding the declaration from parsed data, but it doesn't give any more than 3% speedup, so IMO the increased complexity wasn't worth it

Feel free to close if the error is valuable.

Coincidentally it also removes the sole use case for `rule_set_exceptions`, so i had to emulate the error in tests.

## Pre-Merge Checklist

- [x] CHANGELOG.md updated with short summary
