### PR TITLE
Add Subresource Integrity (SRI) verification for remote stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Ruby CSS Parser CHANGELOG
 
 ### Unreleased
+* `Parser#load_uri!` accepts an `integrity:` option (Subresource Integrity, https://www.w3.org/TR/SRI/) to verify a fetched remote stylesheet before it is parsed
 
 ### Version 3.0.0
 * Harden read_remote_file, use `allow_local_network: true` and `allow_file_uris: true` to bypass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     css_parser (3.0.0)
       addressable
+      base64
       ssrf_filter (~> 1.5)
 
 GEM
@@ -11,6 +12,7 @@ GEM
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    base64 (0.2.0)
     benchmark-ips (2.14.0)
     bump (0.10.0)
     json (2.18.1)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ parser.load_uri!('../style.css', {base_uri: 'http://example.com/styles/inc/', me
 # doesn't match.
 parser.load_uri!('http://example.com/styles/style.css', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC')
 
+# `integrity:` also accepts several space-separated values, exactly like the
+# HTML attribute does. When more than one hash algorithm is present, only the
+# strongest one is checked (sha512 > sha384 > sha256) and every weaker value is
+# ignored; multiple values for that same strongest algorithm are treated as
+# alternatives -- matching any one of them is enough.
+parser.load_uri!(
+  'http://example.com/styles/style.css',
+  integrity: 'sha256-Br6tO8uuFyBAw2O0eUNdXVyuS/POLb5jpHxXaxIq6Q0= sha384-0gCPKBW0n+VzQzZu5gzP+YMxy9QTLyn1y/O/TMvLTpVajzRKAx6d7TiPB5W7DnDn'
+)
+# ^ only the sha384 value is actually checked here; the sha256 one is present
+# (e.g. for browsers/tools that only understand sha256) but ignored by this
+# library since a stronger algorithm is also listed.
+
 # load a local file, setting the base_dir and media_types
 parser.load_file!('print.css', '~/styles/', :print)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ parser.load_uri!('file://home/user/styles/style.css')
 # load a remote file, setting the base_uri and media_types
 parser.load_uri!('../style.css', {base_uri: 'http://example.com/styles/inc/', media_types: [:screen, :handheld]})
 
+# load a remote file, verifying it against a Subresource Integrity value
+# (https://www.w3.org/TR/SRI/) before parsing -- e.g. the value of an
+# HTML <link integrity="..."> attribute. Raises CssParser::RemoteFileError
+# (or, with io_exceptions: false, loads nothing) when the fetched body
+# doesn't match.
+parser.load_uri!('http://example.com/styles/style.css', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC')
+
 # load a local file, setting the base_dir and media_types
 parser.load_file!('print.css', '~/styles/', :print)
 

--- a/README.md
+++ b/README.md
@@ -23,26 +23,6 @@ parser.load_uri!('file://home/user/styles/style.css')
 # load a remote file, setting the base_uri and media_types
 parser.load_uri!('../style.css', {base_uri: 'http://example.com/styles/inc/', media_types: [:screen, :handheld]})
 
-# load a remote file, verifying it against a Subresource Integrity value
-# (https://www.w3.org/TR/SRI/) before parsing -- e.g. the value of an
-# HTML <link integrity="..."> attribute. Raises CssParser::RemoteFileError
-# (or, with io_exceptions: false, loads nothing) when the fetched body
-# doesn't match.
-parser.load_uri!('http://example.com/styles/style.css', integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC')
-
-# `integrity:` also accepts several space-separated values, exactly like the
-# HTML attribute does. When more than one hash algorithm is present, only the
-# strongest one is checked (sha512 > sha384 > sha256) and every weaker value is
-# ignored; multiple values for that same strongest algorithm are treated as
-# alternatives -- matching any one of them is enough.
-parser.load_uri!(
-  'http://example.com/styles/style.css',
-  integrity: 'sha256-Br6tO8uuFyBAw2O0eUNdXVyuS/POLb5jpHxXaxIq6Q0= sha384-0gCPKBW0n+VzQzZu5gzP+YMxy9QTLyn1y/O/TMvLTpVajzRKAx6d7TiPB5W7DnDn'
-)
-# ^ only the sha384 value is actually checked here; the sha256 one is present
-# (e.g. for browsers/tools that only understand sha256) but ignored by this
-# library since a stronger algorithm is also listed.
-
 # load a local file, setting the base_dir and media_types
 parser.load_file!('print.css', '~/styles/', :print)
 
@@ -89,6 +69,39 @@ content_rule.filename
 #=> 'index.html'
 content_rule.offset
 #=> 0..21
+```
+
+# Subresource Integrity
+
+`Parser#load_uri!` accepts an `integrity:` option that verifies a fetched remote stylesheet
+against a [Subresource Integrity](https://www.w3.org/TR/SRI/) value before it's parsed -- the
+same value an HTML `<link integrity="...">` attribute carries.
+
+```Ruby
+parser.load_uri!(
+  'http://example.com/styles/style.css',
+  integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'
+)
+```
+
+When the fetched body doesn't match, `CssParser::IntegrityError` (a subclass of
+`CssParser::RemoteFileError`, so existing `rescue RemoteFileError` code is unaffected) is
+raised if `io_exceptions` is enabled, or nothing is loaded otherwise.
+
+`integrity:` also accepts several space-separated values, exactly like the HTML attribute
+does. When more than one hash algorithm is present, only the strongest one is checked
+(sha512 > sha384 > sha256) and every weaker value is ignored; multiple values for that same
+strongest algorithm are treated as alternatives -- matching any one of them is enough (useful
+during a stylesheet rotation, when a CDN may still serve the old version for a while):
+
+```Ruby
+parser.load_uri!(
+  'http://example.com/styles/style.css',
+  integrity: 'sha256-Br6tO8uuFyBAw2O0eUNdXVyuS/POLb5jpHxXaxIq6Q0= sha384-0gCPKBW0n+VzQzZu5gzP+YMxy9QTLyn1y/O/TMvLTpVajzRKAx6d7TiPB5W7DnDn'
+)
+# only the sha384 value is actually checked here; the sha256 one is present
+# (e.g. for browsers/tools that only understand sha256) but ignored by this
+# library since a stronger algorithm is also listed.
 ```
 
 # Testing

--- a/css_parser.gemspec
+++ b/css_parser.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new name, CssParser::VERSION do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
 
   s.add_dependency 'addressable'
+  s.add_dependency 'base64'
   s.add_dependency 'ssrf_filter', '~> 1.5'
 end

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'strscan'
+require 'digest'
+require 'base64'
 
 module CssParser
   # Exception class used for any errors encountered while downloading remote files.
@@ -19,6 +21,9 @@ module CssParser
   # [<tt>io_exceptions</tt>] Throw an exception if a link can not be found. Boolean, default is <tt>true</tt>.
   # [<tt>allow_local_network</tt>] Permit http(s) fetches against loopback / private / link-local / cloud-metadata addresses. Boolean, default is <tt>false</tt>. When <tt>false</tt> (the default), outbound HTTP requests are routed through <tt>ssrf_filter</tt>, which resolves the host and rejects unsafe IP ranges. Set to <tt>true</tt> only when the destination is known to be safe (e.g. local fixture servers in tests). Independent of <tt>allow_file_uris</tt>.
   # [<tt>allow_file_uris</tt>] Permit <tt>file://</tt> URIs via <tt>load_uri!</tt>. Boolean, default is <tt>false</tt>. When <tt>false</tt> (the default), a caller that passes a <tt>file://</tt> URI to <tt>load_uri!</tt> — directly or via a CSS <tt>@import</tt> resolved against a <tt>file://</tt> base_uri — is refused, closing the local-file-disclosure vector when the URI is influenced by user input. <tt>load_file!</tt> is unaffected: it is the explicit local-file API and takes a caller-supplied path. Independent of <tt>allow_local_network</tt>.
+  #
+  # <tt>load_uri!</tt> also accepts a per-call <tt>:integrity</tt> option (see its documentation) for
+  # verifying a remote stylesheet against a Subresource Integrity value before it is parsed.
   class Parser
     USER_AGENT = "Ruby CSS Parser/#{CssParser::VERSION} (https://github.com/premailer/css_parser)".freeze
     RULESET_TOKENIZER_RX = /\s+|\\{2,}|\\?[{}\s"]|[()]|.[^\s"{}()\\]*/.freeze
@@ -36,6 +41,13 @@ module CssParser
     # closes the cross-scheme redirect (HTTP 3xx → `file://`) vector that
     # was GHSA-9pmc-p236-855h.
     REMOTE_ALLOWED_SCHEMES = %w[http https].freeze
+
+    # Subresource Integrity hash algorithms this library can verify,
+    # strongest first. Mirrors the SRI spec's "agility" rule
+    # (https://www.w3.org/TR/SRI/#agility): when a caller-supplied
+    # `integrity` value lists more than one algorithm, only the
+    # strongest one present is checked.
+    INTEGRITY_ALGORITHM_PRIORITY = %w[sha512 sha384 sha256].freeze
 
     # Array of CSS files that have been loaded.
     attr_reader :loaded_uris
@@ -492,7 +504,12 @@ module CssParser
     #
     # You can also pass in file://test.css
     #
-    # See add_block! for options.
+    # See add_block! for options. In addition to those, <tt>:integrity</tt> accepts a
+    # Subresource Integrity value (https://www.w3.org/TR/SRI/) -- e.g. the value of an
+    # HTML <tt><link integrity="..."></tt> attribute -- and, for http(s) URIs, verifies the
+    # fetched response body against it before the CSS is parsed. When the digest does not
+    # match, the fetch is treated as a failure: an exception is raised if <tt>io_exceptions</tt>
+    # is enabled, otherwise nothing is loaded. Ignored for <tt>file://</tt> URIs.
     #
     # Deprecated: originally accepted three params: `uri`, `base_uri` and `media_types`
     def load_uri!(uri, options = {}, deprecated = nil)
@@ -538,7 +555,7 @@ module CssParser
               end
               read_local_file(uri)
             else
-              src_and_charset, = read_remote_file(uri) # skip charset
+              src_and_charset, = read_remote_file(uri, integrity: opts[:integrity]) # skip charset
               src_and_charset
             end
 
@@ -677,10 +694,14 @@ module CssParser
     # is still validated on every redirect hop, so cross-scheme
     # redirect to `file://` (the original GHSA-9pmc-p236-855h sink)
     # remains closed even on this opt-in path.
+    #
+    # `integrity:`, when given, is verified against the raw response body
+    # (before charset decoding, matching Subresource Integrity semantics)
+    # -- see `integrity_matches?` and `load_uri!`'s documentation.
     #--
     # TODO: add option to fail silently or throw and exception on a 404
     #++
-    def read_remote_file(uri) # :nodoc:
+    def read_remote_file(uri, integrity: nil) # :nodoc:
       uri = Addressable::URI.parse(uri.to_s)
 
       unless circular_reference_check(uri.to_s)
@@ -711,6 +732,12 @@ module CssParser
           return '', nil
         end
 
+        if integrity && !integrity_matches?(res.body, integrity)
+          raise RemoteFileError, uri.to_s if @options[:io_exceptions]
+
+          return nil, nil
+        end
+
         charset = res.respond_to?(:charset) ? res.encoding : 'utf-8'
         src = res.body
         src.encode!('UTF-8', charset) if charset
@@ -721,6 +748,33 @@ module CssParser
 
         [nil, nil]
       end
+    end
+
+    # Verifies +body+ (raw response bytes, not yet charset-decoded) against a
+    # Subresource Integrity value -- a single `<algorithm>-<base64 digest>` token, or
+    # several whitespace-separated tokens (https://www.w3.org/TR/SRI/#the-integrity-attribute).
+    # Tokens using an algorithm this library doesn't recognize are ignored; per the spec's
+    # "agility" rule, when multiple recognized algorithms are present only the strongest one
+    # is checked. A value containing no recognized algorithm is treated as unverifiable and
+    # matches by default, rather than failing every fetch whenever a caller passes a stronger
+    # or newer algorithm than this library currently supports.
+    def integrity_matches?(body, integrity) # :nodoc:
+      candidates = integrity.to_s.split.filter_map do |token|
+        algorithm, value = token.split('-', 2)
+        [algorithm, value] if algorithm && value && INTEGRITY_ALGORITHM_PRIORITY.include?(algorithm)
+      end
+      return true if candidates.empty?
+
+      algorithm = candidates.map(&:first).min_by { |a| INTEGRITY_ALGORITHM_PRIORITY.index(a) }
+      expected_values = candidates.select { |a, _v| a == algorithm }.map { |_a, v| v }
+
+      digest_class = {
+        'sha512' => Digest::SHA512,
+        'sha384' => Digest::SHA384,
+        'sha256' => Digest::SHA256
+      }.fetch(algorithm)
+
+      expected_values.include?(Base64.strict_encode64(digest_class.digest(body)))
     end
 
     # Net::HTTP path used only when `allow_local_network: true`. Validates

--- a/lib/css_parser/parser.rb
+++ b/lib/css_parser/parser.rb
@@ -8,6 +8,13 @@ module CssParser
   # Exception class used for any errors encountered while downloading remote files.
   class RemoteFileError < IOError; end
 
+  # Exception class used when a fetched remote file fails Subresource Integrity
+  # verification (see the `:integrity` option on `Parser#load_uri!`). A subclass of
+  # `RemoteFileError` so existing `rescue RemoteFileError` callers are unaffected;
+  # callers that want to distinguish an integrity failure from other fetch failures
+  # (404, SSRF rejection, timeout, etc.) can rescue this class specifically.
+  class IntegrityError < RemoteFileError; end
+
   # Exception class used if a request is made to load a CSS file more than once.
   class CircularReferenceError < StandardError; end
 
@@ -42,12 +49,17 @@ module CssParser
     # was GHSA-9pmc-p236-855h.
     REMOTE_ALLOWED_SCHEMES = %w[http https].freeze
 
-    # Subresource Integrity hash algorithms this library can verify,
-    # strongest first. Mirrors the SRI spec's "agility" rule
-    # (https://www.w3.org/TR/SRI/#agility): when a caller-supplied
-    # `integrity` value lists more than one algorithm, only the
-    # strongest one present is checked.
-    INTEGRITY_ALGORITHM_PRIORITY = %w[sha512 sha384 sha256].freeze
+    # Subresource Integrity hash algorithms this library can verify, mapped to their
+    # Digest class, ordered strongest first. A single structure (rather than a
+    # separate priority list and digest-class lookup) so the two can't drift out of
+    # sync. Mirrors the SRI spec's "agility" rule (https://www.w3.org/TR/SRI/#agility):
+    # when a caller-supplied `integrity` value lists more than one algorithm, only
+    # the strongest one present is checked.
+    INTEGRITY_ALGORITHMS = {
+      'sha512' => Digest::SHA512,
+      'sha384' => Digest::SHA384,
+      'sha256' => Digest::SHA256
+    }.freeze
 
     # Array of CSS files that have been loaded.
     attr_reader :loaded_uris
@@ -508,8 +520,9 @@ module CssParser
     # Subresource Integrity value (https://www.w3.org/TR/SRI/) -- e.g. the value of an
     # HTML <tt><link integrity="..."></tt> attribute -- and, for http(s) URIs, verifies the
     # fetched response body against it before the CSS is parsed. When the digest does not
-    # match, the fetch is treated as a failure: an exception is raised if <tt>io_exceptions</tt>
-    # is enabled, otherwise nothing is loaded. Ignored for <tt>file://</tt> URIs.
+    # match, <tt>CssParser::IntegrityError</tt> (a subclass of <tt>RemoteFileError</tt>) is
+    # raised if <tt>io_exceptions</tt> is enabled, otherwise nothing is loaded. Ignored for
+    # <tt>file://</tt> URIs.
     #
     # Deprecated: originally accepted three params: `uri`, `base_uri` and `media_types`
     def load_uri!(uri, options = {}, deprecated = nil)
@@ -733,7 +746,7 @@ module CssParser
         end
 
         if integrity && !integrity_matches?(res.body, integrity)
-          raise RemoteFileError, uri.to_s if @options[:io_exceptions]
+          raise IntegrityError, uri.to_s if @options[:io_exceptions]
 
           return nil, nil
         end
@@ -743,6 +756,16 @@ module CssParser
         src.encode!('UTF-8', charset) if charset
 
         [src, charset]
+      rescue IntegrityError
+        # Let the IntegrityError raised above propagate with its specific
+        # class intact, rather than being downgraded to a generic
+        # RemoteFileError by the catch-all below. Other RemoteFileErrors
+        # raised within this method (e.g. from fetch_via_net_http on a
+        # cross-scheme redirect) are intentionally still caught by the
+        # catch-all: it discards their (potentially redirect-target-scoped)
+        # message in favor of this method's own `uri`, which several
+        # existing tests depend on.
+        raise
       rescue
         raise RemoteFileError, uri.to_s if @options[:io_exceptions]
 
@@ -761,18 +784,14 @@ module CssParser
     def integrity_matches?(body, integrity) # :nodoc:
       candidates = integrity.to_s.split.filter_map do |token|
         algorithm, value = token.split('-', 2)
-        [algorithm, value] if algorithm && value && INTEGRITY_ALGORITHM_PRIORITY.include?(algorithm)
+        [algorithm, value] if algorithm && value && INTEGRITY_ALGORITHMS.key?(algorithm)
       end
       return true if candidates.empty?
 
-      algorithm = candidates.map(&:first).min_by { |a| INTEGRITY_ALGORITHM_PRIORITY.index(a) }
+      algorithms_present = candidates.map(&:first)
+      algorithm = INTEGRITY_ALGORITHMS.each_key.find { |a| algorithms_present.include?(a) }
       expected_values = candidates.select { |a, _v| a == algorithm }.map { |_a, v| v }
-
-      digest_class = {
-        'sha512' => Digest::SHA512,
-        'sha384' => Digest::SHA384,
-        'sha256' => Digest::SHA256
-      }.fetch(algorithm)
+      digest_class = INTEGRITY_ALGORITHMS.fetch(algorithm)
 
       expected_values.include?(Base64.strict_encode64(digest_class.digest(body)))
     end

--- a/test/test_css_parser_integrity.rb
+++ b/test/test_css_parser_integrity.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Tests for `Parser#load_uri!`'s `:integrity` option, which verifies a
+# fetched remote stylesheet against a Subresource Integrity value
+# (https://www.w3.org/TR/SRI/) before it is parsed -- the same mechanism
+# an HTML `<link integrity="...">` attribute describes.
+class CssParserIntegrityTests < Minitest::Test
+  include CssParser
+  include WEBrick
+
+  PORT = 12_011
+
+  def setup
+    @www_root = File.expand_path('fixtures', __dir__)
+    @fixture_file = File.expand_path('fixtures/simple.css', __dir__)
+    @fixture_body = File.binread(@fixture_file)
+    @uri_base = "http://127.0.0.1:#{PORT}"
+
+    # `:integrity` verification only applies on the remote-fetch path, so
+    # these tests use `allow_local_network: true` against a loopback
+    # fixture server rather than mocking the HTTP layer -- matching the
+    # approach `test_allow_local_network_opt_in_permits_loopback` uses in
+    # test_css_parser_ssrf.rb.
+    @server_thread = Thread.new do
+      s = WEBrick::HTTPServer.new(
+        Port: PORT, BindAddress: '127.0.0.1', DocumentRoot: @www_root,
+        Logger: Log.new(nil, BasicLog::FATAL), AccessLog: []
+      )
+      begin
+        s.start
+      ensure
+        s.shutdown
+      end
+    end
+
+    sleep 1
+  end
+
+  def teardown
+    @server_thread.kill
+    @server_thread.join(5)
+    @server_thread = nil
+  end
+
+  def cp
+    Parser.new(allow_local_network: true)
+  end
+
+  def sha(algorithm, body = @fixture_body)
+    digest_class = {'sha256' => Digest::SHA256, 'sha384' => Digest::SHA384, 'sha512' => Digest::SHA512}.fetch(algorithm)
+    "#{algorithm}-#{Base64.strict_encode64(digest_class.digest(body))}"
+  end
+
+  def test_load_uri_without_integrity_option_is_unaffected
+    cp.load_uri!("#{@uri_base}/simple.css")
+    # no-op: reaching here without an exception is the assertion.
+  end
+
+  def test_matching_sha384_integrity_loads_normally
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: sha('sha384'))
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+
+  def test_matching_sha256_integrity_loads_normally
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: sha('sha256'))
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+
+  def test_matching_sha512_integrity_loads_normally
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: sha('sha512'))
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+
+  def test_mismatched_integrity_is_refused
+    tampered = "#{sha('sha384')[0, 15]}not-the-real-digest-at-all=="
+    assert_raises(CssParser::RemoteFileError) do
+      cp.load_uri!("#{@uri_base}/simple.css", integrity: tampered)
+    end
+  end
+
+  def test_mismatched_integrity_without_io_exceptions_loads_nothing
+    parser = Parser.new(allow_local_network: true, io_exceptions: false)
+    tampered = "#{sha('sha384')[0, 15]}not-the-real-digest-at-all=="
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: tampered)
+    assert_empty parser.find_by_selector('p')
+  end
+
+  def test_strongest_algorithm_wins_when_multiple_present_and_it_fails
+    # A correct sha256 paired with a wrong sha512 must fail -- the spec's
+    # "agility" rule means only the strongest present algorithm (sha512
+    # here) is authoritative, so a right-but-weaker value must not mask
+    # a wrong-but-stronger one.
+    value = "#{sha('sha256')} sha512-#{Base64.strict_encode64('not the real digest')}"
+    assert_raises(CssParser::RemoteFileError) do
+      cp.load_uri!("#{@uri_base}/simple.css", integrity: value)
+    end
+  end
+
+  def test_strongest_algorithm_wins_when_multiple_present_and_it_passes
+    # Mirror of the above: a wrong sha256 paired with a correct sha512
+    # must still pass, since sha512 is the one actually checked.
+    wrong_sha256 = "sha256-#{Base64.strict_encode64('not the real digest')}"
+    value = "#{wrong_sha256} #{sha('sha512')}"
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: value)
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+
+  def test_multiple_values_for_the_same_algorithm_accepts_any_match
+    # The spec allows several acceptable digests for the same algorithm
+    # (e.g. during a stylesheet rotation) -- any match should pass.
+    other_value = "sha384-#{Base64.strict_encode64('some other build of the file')}"
+    value = "#{other_value} #{sha('sha384')}"
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: value)
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+
+  def test_unrecognized_algorithm_only_value_is_unverifiable_and_passes
+    # md5 is not in INTEGRITY_ALGORITHM_PRIORITY. A value naming only an
+    # unsupported algorithm can't be checked either way, so it's treated
+    # as unverifiable rather than failing every such fetch.
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: 'md5-deadbeef==')
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+
+  def test_blank_integrity_option_is_unaffected
+    parser = cp
+    parser.load_uri!("#{@uri_base}/simple.css", integrity: '')
+    assert_equal 'margin: 0px;', parser.find_by_selector('p').join(' ')
+  end
+end

--- a/test/test_css_parser_integrity.rb
+++ b/test/test_css_parser_integrity.rb
@@ -78,6 +78,15 @@ class CssParserIntegrityTests < Minitest::Test
 
   def test_mismatched_integrity_is_refused
     tampered = "#{sha('sha384')[0, 15]}not-the-real-digest-at-all=="
+    assert_raises(CssParser::IntegrityError) do
+      cp.load_uri!("#{@uri_base}/simple.css", integrity: tampered)
+    end
+  end
+
+  def test_mismatched_integrity_raises_a_subclass_of_remote_file_error
+    # CssParser::IntegrityError must remain catchable by existing
+    # `rescue RemoteFileError` callers.
+    tampered = "#{sha('sha384')[0, 15]}not-the-real-digest-at-all=="
     assert_raises(CssParser::RemoteFileError) do
       cp.load_uri!("#{@uri_base}/simple.css", integrity: tampered)
     end
@@ -96,7 +105,7 @@ class CssParserIntegrityTests < Minitest::Test
     # here) is authoritative, so a right-but-weaker value must not mask
     # a wrong-but-stronger one.
     value = "#{sha('sha256')} sha512-#{Base64.strict_encode64('not the real digest')}"
-    assert_raises(CssParser::RemoteFileError) do
+    assert_raises(CssParser::IntegrityError) do
       cp.load_uri!("#{@uri_base}/simple.css", integrity: value)
     end
   end
@@ -122,7 +131,7 @@ class CssParserIntegrityTests < Minitest::Test
   end
 
   def test_unrecognized_algorithm_only_value_is_unverifiable_and_passes
-    # md5 is not in INTEGRITY_ALGORITHM_PRIORITY. A value naming only an
+    # md5 is not in INTEGRITY_ALGORITHMS. A value naming only an
     # unsupported algorithm can't be checked either way, so it's treated
     # as unverifiable rather than failing every such fetch.
     parser = cp


### PR DESCRIPTION
## What

Adds an `integrity:` option to `Parser#load_uri!` that verifies a fetched remote stylesheet against a [Subresource Integrity](https://www.w3.org/TR/SRI/) value before it's parsed — the same value an HTML `<link integrity="...">` attribute carries.

```ruby
parser.load_uri!(
  'http://example.com/styles/style.css',
  integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC'
)
```

- Supports `sha256`/`sha384`/`sha512`, **multiple space-separated values in one `integrity:` string** (exactly like the HTML attribute), and the spec's "agility" rule: when a value lists more than one algorithm, only the strongest present one is actually checked, and every weaker one is ignored outright — e.g. `sha256-... sha384-...` only checks the sha384 value. When several values are given for that same strongest algorithm (e.g. during a planned key/stylesheet rotation), matching any one of them is enough.
- A value naming only an algorithm this library doesn't recognize is treated as unverifiable (passes through) rather than failing every such fetch.
- On mismatch, the fetch fails the same way other remote-fetch failures already do here: raises `CssParser::RemoteFileError` when `io_exceptions` is enabled, otherwise loads nothing.

## Why

Consumers of this gem that already know the expected digest of a linked stylesheet (for example, because it came from an HTML `<link integrity="...">` attribute they're processing) currently have no way to ask `load_uri!` to verify it — the fetched body is trusted unconditionally regardless of what the caller expected. This gives callers an opt-in way to fail closed instead.

## Testing

- New `test/test_css_parser_integrity.rb`, covering: normal pass-through when the option is omitted, all three supported algorithms, mismatch handling (with and without `io_exceptions`), the multi-algorithm "agility" rule in both directions (weaker-correct+stronger-wrong fails, weaker-wrong+stronger-correct passes), multiple acceptable values for one algorithm, and the unsupported-algorithm-is-unverifiable case.
- Full existing suite passes (`bundle exec rake test`) — no behavior change when `integrity:` isn't passed.
- `bundle exec rubocop` clean on the changed files.

Happy to adjust the option name/shape or add doc updates elsewhere if you'd rather it live somewhere other than `load_uri!`.